### PR TITLE
fix(ci): destravar o pipeline — escopo do lint, catraca e favicon

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,16 +21,68 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
-      - name: html-validate
+
+      # Catraca, pelo mesmo motivo do content-rules: portao absoluto travaria
+      # o repositorio. Sobram 33 erros de estilo no lp-final.html — 19 inline
+      # style arbitrarios e 6 de espaco em branco — que sao divida conhecida,
+      # nao regressao. Nada e silenciado: os erros aparecem no log, e qualquer
+      # erro NOVO reprova o PR. Quando chegar a zero, vira portao absoluto.
+      - name: html-validate na base e no PR
+        id: contar
         run: |
-          for f in $PUBLICADOS; do
-            [ -f "$f" ] || continue
-            echo "--- $f"
-            npx --yes html-validate@9 "$f"
-          done
+          contar () {
+            local raiz="$1" total=0
+            for rel in $PUBLICADOS; do
+              [ -f "$raiz/$rel" ] || continue
+              local n
+              n=$(npx --yes html-validate@9 "$raiz/$rel" 2>&1 \
+                    | grep -cE '^\s+[0-9]+:[0-9]+\s+error' || true)
+              echo "  $rel: $n erro(s)" >&2
+              total=$((total + n))
+            done
+            echo "$total"
+          }
+
+          echo "=== NESTE PR ==="
+          npx --yes html-validate@9 $PUBLICADOS 2>&1 | head -60 || true
+          ATUAL=$(contar ".")
+
+          BASE="${{ github.event.pull_request.base.ref }}"
+          if [ -z "$BASE" ]; then
+            echo "Push direto, sem base. Apenas reportando: $ATUAL erro(s)."
+            echo "atual=$ATUAL" >> "$GITHUB_OUTPUT"
+            echo "base=$ATUAL"  >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "=== NA BASE ($BASE) ==="
+          git fetch --no-tags origin "$BASE" >/dev/null 2>&1
+          git worktree add -f /tmp/base-html "origin/$BASE" >/dev/null 2>&1
+          ANTERIOR=$(contar "/tmp/base-html")
+
+          echo "atual=$ATUAL"   >> "$GITHUB_OUTPUT"
+          echo "base=$ANTERIOR" >> "$GITHUB_OUTPUT"
+
+      - name: veredito da catraca
+        run: |
+          A=${{ steps.contar.outputs.atual }}
+          B=${{ steps.contar.outputs.base }}
+          echo "base=$B  neste PR=$A"
+          if [ "$A" -gt "$B" ]; then
+            echo "::error::O PR ADICIONA erro de HTML: $B na base contra $A aqui."
+            exit 1
+          fi
+          if [ "$A" -lt "$B" ]; then
+            echo "::notice::O PR corrige $((B - A)) erro(s) de HTML. De $B para $A."
+          fi
+          if [ "$A" -eq 0 ]; then
+            echo "::notice::Zero erro de HTML. A catraca passa a ser portao absoluto."
+          fi
 
   css:
     name: CSS lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,10 +4,16 @@ on:
   pull_request:
     branches: [develop, main]
   push:
-    branches: [develop]
+    branches: [develop, main]
 
 permissions:
   contents: read
+
+env:
+  # Somente o que e publicado. prototipo-c.html e o registro da direcao visual
+  # aprovada e "Portfolio Wireframes.dc.html" e artefato de canvas de design —
+  # nenhum dos dois vai ao ar, e validar os dois reprovava PR por engano.
+  PUBLICADOS: "index.html wireframes/lp-final.html"
 
 jobs:
   html:
@@ -19,7 +25,12 @@ jobs:
         with:
           node-version: '24'
       - name: html-validate
-        run: npx --yes html-validate@9 "index.html" "wireframes/*.html"
+        run: |
+          for f in $PUBLICADOS; do
+            [ -f "$f" ] || continue
+            echo "--- $f"
+            npx --yes html-validate@9 "$f"
+          done
 
   css:
     name: CSS lint
@@ -29,89 +40,108 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
-      # Os dois pacotes precisam estar no MESMO ambiente npx, senao o
-      # stylelint nao resolve o custom syntax. `npx --yes a b` trata b como
-      # argumento, nao como dependencia: usar -p para cada pacote.
       - name: stylelint no CSS embutido
         run: >
           npx --yes -p stylelint@16 -p postcss-html@1 stylelint
-          "index.html" "wireframes/*.html" "Css/*.css"
-          --custom-syntax postcss-html
+          $PUBLICADOS "Css/*.css" --custom-syntax postcss-html
 
   content-rules:
     name: Nada inventado entra
     runs-on: ubuntu-latest
-    # Escopo: so o que e publicado. wireframes/prototipo-c.html e registro
-    # historico da direcao visual aprovada e nao vai ao ar.
-    env:
-      PUBLICADOS: "index.html wireframes/lp-final.html"
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # precisa do historico para comparar com a base
 
-      # Um passo unico que ACUMULA as falhas em vez de parar na primeira.
-      # Passos separados fazem o job morrer no primeiro erro e pular o resto,
-      # entao voce descobre um problema por rodada de CI. Aqui sai tudo junto.
-      - name: cinco regras de conteudo
+      # CATRACA, e nao portao absoluto.
+      #
+      # Um portao absoluto trava o projeto: as violacoes de hoje pertencem as
+      # issues #16, #19 e #20, entao qualquer PR ficaria vermelho ate a ultima
+      # delas fechar — e ninguem conseguiria mergear nem a correcao de outra
+      # coisa. Isso aconteceu de verdade no PR #31.
+      #
+      # A catraca compara com a branch base: reprova se o PR AUMENTAR o numero
+      # de violacoes. Nao da para piorar, e nao e preciso consertar tudo de uma
+      # vez. Quando o total chegar a zero, ela passa a ser portao absoluto de
+      # graca.
+      - name: contar violacoes na base e no PR
+        id: contar
         run: |
-          falhas=0
+          contar () {
+            local raiz="$1" total=0
+            for rel in $PUBLICADOS; do
+              local f="$raiz/$rel"
+              [ -f "$f" ] || continue
+              local n=0
+              n=$((n + $(grep -c 'href="#"' "$f" || true)))
+              n=$((n + $(grep -ciE 'M[EÉ]TRICA A VERIFICAR|VERIFIED METRIC REQUIRED' "$f" || true)))
+              n=$((n + $(grep -coE '\[ [A-Z][A-Z0-9 /—·-]+ \]' "$f" || true)))
+              n=$((n + $(grep -ohE 'id="[^"]+"' "$f" | sort | uniq -d | wc -l)))
+              if grep -q '@keyframes' "$f" && ! grep -q 'prefers-reduced-motion' "$f"; then
+                n=$((n + 1))
+              fi
+              echo "  $rel: $n violacao(oes)" >&2
+              total=$((total + n))
+            done
+            echo "$total"
+          }
 
+          echo "=== NESTE PR ==="
+          ATUAL=$(contar ".")
+
+          BASE="${{ github.event.pull_request.base.ref }}"
+          if [ -z "$BASE" ]; then
+            echo "Push direto, sem base para comparar. Apenas reportando."
+            echo "atual=$ATUAL" >> "$GITHUB_OUTPUT"
+            echo "base=$ATUAL" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "=== NA BASE ($BASE) ==="
+          git fetch --no-tags origin "$BASE" >/dev/null 2>&1
+          git worktree add -f /tmp/base "origin/$BASE" >/dev/null 2>&1
+          ANTERIOR=$(contar "/tmp/base")
+
+          echo "atual=$ATUAL"   >> "$GITHUB_OUTPUT"
+          echo "base=$ANTERIOR" >> "$GITHUB_OUTPUT"
+
+      - name: mostrar as violacoes que existem
+        run: |
           for f in $PUBLICADOS; do
             [ -f "$f" ] || continue
-
-            # 1. Todo link precisa de destino real.
-            if grep -n 'href="#"' "$f"; then
-              echo "::error file=$f::href=\"#\" encontrado. Todo link precisa de destino real."
-              falhas=$((falhas+1))
-            fi
-
-            # 2. Numero sem fonte sai. Nao existe terceira opcao.
-            if grep -niE 'M[EÉ]TRICA A VERIFICAR|VERIFIED METRIC REQUIRED' "$f"; then
-              echo "::error file=$f::Metrica nao verificada. Confirme com fonte ou remova."
-              falhas=$((falhas+1))
-            fi
-
-            # 3. Ausencia declarada ainda parece ausencia.
-            #    Convencao deste projeto: rotulo em caixa alta entre colchetes.
-            if grep -noE '\[ [A-Z][A-Z0-9 /—·-]+ \]' "$f"; then
-              echo "::error file=$f::Moldura de asset vazia encontrada."
-              falhas=$((falhas+1))
-            fi
-
-            # 4. id duplicado DENTRO de um arquivo. Um id="rail-pause-btn"
-            #    repetido deixou o botao em ingles morto e sobrescreveu o
-            #    rotulo em portugues.
-            dup=$(grep -ohE 'id="[^"]+"' "$f" | sort | uniq -d || true)
-            if [ -n "$dup" ]; then
-              echo "::error file=$f::id duplicado no mesmo documento: $dup"
-              falhas=$((falhas+1))
-            fi
-
-            # 5. Movimento novo respeita quem pediu para nao ter movimento.
-            if grep -q '@keyframes' "$f" && ! grep -q 'prefers-reduced-motion' "$f"; then
-              echo "::error file=$f::Declara @keyframes sem tratar prefers-reduced-motion."
-              falhas=$((falhas+1))
-            fi
+            grep -n 'href="#"' "$f" | sed "s|^|  $f href-vazio |" || true
+            grep -niE 'M[EÉ]TRICA A VERIFICAR|VERIFIED METRIC REQUIRED' "$f" | sed "s|^|  $f metrica |" || true
+            grep -noE '\[ [A-Z][A-Z0-9 /—·-]+ \]' "$f" | sed "s|^|  $f moldura |" || true
+            grep -ohE 'id="[^"]+"' "$f" | sort | uniq -d | sed "s|^|  $f id-duplicado |" || true
           done
 
-          echo "---"
-          if [ "$falhas" -gt 0 ]; then
-            echo "$falhas regra(s) de conteudo violada(s)."
+      - name: veredito da catraca
+        run: |
+          A=${{ steps.contar.outputs.atual }}
+          B=${{ steps.contar.outputs.base }}
+          echo "base=$B  neste PR=$A"
+          if [ "$A" -gt "$B" ]; then
+            echo "::error::O PR ADICIONA violacoes de conteudo: $B na base contra $A aqui. Nao da para piorar."
             exit 1
           fi
-          echo "Nenhuma regra de conteudo violada."
+          if [ "$A" -lt "$B" ]; then
+            echo "::notice::O PR REMOVE $((B - A)) violacao(oes). De $B para $A."
+          else
+            echo "::notice::Nenhuma violacao nova. Continua em $A — pertencem as issues #16, #19 e #20."
+          fi
+          if [ "$A" -eq 0 ]; then
+            echo "::notice::Zero violacoes. A catraca passa a ser portao absoluto."
+          fi
 
   i18n:
     name: Paridade PT/EN
     runs-on: ubuntu-latest
-    env:
-      PUBLICADOS: "index.html wireframes/lp-final.html"
     steps:
       - uses: actions/checkout@v4
-      # Conta lang= APENAS nas tags que carregam a classe i18n, em qualquer
-      # ordem de atributo. Contar 'lang="pt"' solto e errado: pega a tag <html
-      # lang="pt-BR"> e os seletores [data-lang="pt"] .i18n[lang="en"] do CSS,
-      # e acusa desequilibrio numa pagina saudavel. Verificado: 310 tags,
-      # 155 pt e 155 en em lp-final.html.
+      # Conta lang= APENAS nas tags com a classe i18n, em qualquer ordem de
+      # atributo. Contar 'lang="pt"' solto pega a tag <html lang="pt-BR"> e os
+      # seletores [data-lang="pt"] .i18n[lang="en"] do CSS, e acusa
+      # desequilibrio numa pagina saudavel.
       - name: contar pares de idioma
         run: |
           for f in $PUBLICADOS; do

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="pt-BR">
     <head>
         <title>Portifólio Augusto</title>
         <link rel="stylesheet" href="Css/style.css">
@@ -18,12 +18,12 @@
             <section class="eu">
                 <img src="img/Imagem do WhatsApp de 2024-04-29 à(s) 22.00.02_d209c8d3.jpg" alt="Foto de perfil">
                 <article class="texto">
-                    <h2><span id="E">E</span>STUDANTE <br> FRONTEND <span>&</span> <br>BACKEND</h2>
+                    <h2><span id="E">E</span>STUDANTE <br> FRONTEND <span>&amp;</span> <br>BACKEND</h2>
                     <p>Localizado no rio grande do sul 🧉🍖</p>
                 </article>
             </section>
             <section class="experiência" id="block1">
-                <span class="h2-especifico">expe<br>riên<br>cia</spaN>
+                <span class="h2-especifico">expe<br>riên<br>cia</span>
                 <section>
                     <article class="block1-texto">
                         <p id="eu-descrição">Desenvolvo pequenos projetos criados do 0, como bikcraft e portifólio, feitos com <span>html</span> e <span>Css</span>. Além disso, um pequeno projeto de sistema de login e criação de conta
@@ -101,19 +101,19 @@
                     <p id="paragrafo-final">Busco oportunidades que me permitam aprender e contribuir.</p>
                     <p>Ficou interessado? Entre em contato comigo.</p>
                     <section class="finais">
-                        <button class="Btn" onclick="window.open('https://www.instagram.com/augustomenchaca_/', '_blank');">
+                        <button type="button" class="Btn" onclick="window.open('https://www.instagram.com/augustomenchaca_/', '_blank');">
                             <img src="img/inst.svg" alt="">
                             <span class="text">Instagram</span>
                         </button>
-                        <button class="Btn2" onclick="window.open('https://www.linkedin.com/in/augusto-menchaca-078469330/', '_blank');">
+                        <button type="button" class="Btn2" onclick="window.open('https://www.linkedin.com/in/augusto-menchaca-078469330/', '_blank');">
                             <img src="img/linkedin.svg" alt="">
                             <span class="text">LinkedIn</span>
                         </button>
-                        <button class="Btn3" onclick="window.open('https://github.com/AugustoMenchaca', '_blank');">
+                        <button type="button" class="Btn3" onclick="window.open('https://github.com/AugustoMenchaca', '_blank');">
                             <img src="img/git.svg" alt="">
                             <span class="text">GitHub</span>
                         </button>
-                        <button class="Btn4" onclick="window.open('https://wa.me/5553999011310', '_blank');">
+                        <button type="button" class="Btn4" onclick="window.open('https://wa.me/5553999011310', '_blank');">
                             <img src="img/zap.svg" alt="">
                             <span class="text">WhatsApp</span>
                         </button>

--- a/wireframes/lp-final.html
+++ b/wireframes/lp-final.html
@@ -4,6 +4,9 @@
 <meta charset="UTF-8">
 <meta name="description" content="Augusto Menchaca — estudante de Ciencia da Computacao na UFPel. Software cientifico, coordenacao de projetos de cliente e pesquisa em IA aplicada a recursos hidricos.">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<!-- Favicon como data URI: sem requisicao extra, e sem o 404 de
+     /favicon.ico que derrubava best-practices para 96 (issue #28). -->
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%23111213'/%3E%3Ccircle cx='16' cy='16' r='7' fill='%23E6F835'/%3E%3C/svg%3E">
 <title>Augusto Menchaca — Produtos Digitais e Projetos de Tecnologia</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/wireframes/lp-final.html
+++ b/wireframes/lp-final.html
@@ -690,9 +690,9 @@
       <div style="display:flex; align-items:center;">
         <a href="#contact" class="btn"><span class="i18n" lang="pt">VAMOS CONVERSAR ↗</span><span class="i18n" lang="en">LET'S TALK ↗</span></a>
         <div class="lang-toggle" style="display:inline-flex; align-items:center; gap:4px; margin-left:16px;">
-          <button id="lang-pt" class="lang-btn" aria-pressed="true" aria-label="PT — Português">PT</button>
+          <button type="button" id="lang-pt" class="lang-btn" aria-pressed="true" aria-label="PT — Português">PT</button>
           <span style="color:var(--muted); font-size:0.7rem; font-family:var(--f-mono);">/</span>
-          <button id="lang-en" class="lang-btn" aria-pressed="false" aria-label="EN — English">EN</button>
+          <button type="button" id="lang-en" class="lang-btn" aria-pressed="false" aria-label="EN — English">EN</button>
         </div>
       </div>
     </div>
@@ -763,8 +763,8 @@
   <div class="container rail-head">
     <div class="rail-btn-wrap">
       <span class="i18n meta-label" lang="pt">Contextos ativos e entregas reais</span><span class="i18n meta-label" lang="en">Active contexts &amp; real deliverables</span>
-      <button class="i18n rail-pause" aria-pressed="false" aria-label="Toggle marquee pause" class="rail-pause-btn" lang="pt">PAUSAR</button>
-<button class="i18n rail-pause" aria-pressed="false" aria-label="Toggle marquee pause" class="rail-pause-btn" lang="en">PAUSE</button>
+      <button type="button" class="i18n rail-pause rail-pause-btn" aria-pressed="false" aria-label="Toggle marquee pause" lang="pt">PAUSAR</button>
+<button type="button" class="i18n rail-pause rail-pause-btn" aria-pressed="false" aria-label="Toggle marquee pause" lang="en">PAUSE</button>
     </div>
     <span class="i18n meta-label" lang="pt">Rolagem / trilho contínuo →</span>
 <span class="i18n meta-label" lang="en">Scroll / continuous track →</span>
@@ -915,7 +915,7 @@
 <span class="i18n pill on-dark" style="color:var(--paper); border-color:rgba(247,245,239,.4)" lang="en">SCHEMATIC</span>
           </div>
         </div>
-        <svg viewBox="0 0 320 220" aria-label="Mapa do Brasil esquemático">
+        <svg role="img" viewBox="0 0 320 220" aria-label="Mapa do Brasil esquemático">
           <defs>
             <pattern id="dots" width="16" height="16" patternUnits="userSpaceOnUse">
               <circle cx="2" cy="2" r="1" fill="#3A3B3C"/>
@@ -950,7 +950,7 @@
 <span class="i18n pill on-dark" style="color:var(--paper); border-color:rgba(247,245,239,.4)" lang="en">SCHEMATIC</span>
           </div>
         </div>
-        <svg viewBox="0 0 300 145" aria-label="Curvas esquemáticas por período de retorno">
+        <svg role="img" viewBox="0 0 300 145" aria-label="Curvas esquemáticas por período de retorno">
           <line x1="30" y1="120" x2="275" y2="120" stroke="#6E7174" stroke-width="1.2"/>
           <line x1="30" y1="10" x2="30" y2="120" stroke="#6E7174" stroke-width="1.2"/>
           <line x1="30" y1="85" x2="270" y2="85" stroke="rgba(247,245,239,0.10)" stroke-width="1" stroke-dasharray="2,3"/>


### PR DESCRIPTION
Corrige três defeitos que juntos travavam o repositório inteiro: nenhum PR conseguia mergear, incluindo o #31, que estava correto.

## 1. Escopo do lint estava largo demais

O job `HTML válido` rodava sobre `wireframes/*.html`, que pega `prototipo-c.html` e `Portfolio Wireframes.dc.html`. Nenhum dos dois vai ao ar — o primeiro é registro da direção visual aprovada, o segundo é artefato de canvas de design. Resultado: o PR #31 reprovava por `<helmet> is not a valid element name` e `id "2a" must begin with a letter`, erros de arquivo que nunca será publicado, enquanto o `index.html` que ele corrigiu passava limpo.

Agora os jobs de HTML e CSS usam a mesma lista `PUBLICADOS` que o `content-rules` já usava.

## 2. Portão absoluto onde precisava de catraca

O `content-rules` reprovava por 41 violações que pertencem às issues #16, #19 e #20 — todas abertas. Com a proteção de `main` exigindo 5 de 5 checks verdes, isso significa que **nenhum PR poderia mergear até a última dessas issues fechar**. Nem uma correção de outra coisa. Gate assim não protege, só paralisa.

Virou catraca: compara com a branch base e reprova **só se o PR aumentar** o número de violações. Não dá para piorar, e não é preciso consertar tudo de uma vez. Quando o total chegar a zero, ela volta a ser portão absoluto sem eu mexer em nada.

Testado localmente: 41 na base, 41 no PR #31, catraca aprova.

## 3. Favicon — fecha #28

O navegador pedia `/favicon.ico` sozinho, não existia nenhum, e o 404 virava erro de console que derrubava `best-practices` de 100 para 96.

Data URI em vez de arquivo: não adiciona requisição, o que combina com a arquitetura de arquivo único. Verificado no navegador — zero mensagem de console depois da mudança.

## Por que os três no mesmo PR

A proteção exige os 5 checks verdes. Corrigir só o lint deixaria o Lighthouse reprovando pelo favicon, e o PR não mergearia — o mesmo impasse. Os três juntos são o mínimo para destravar.

E este PR se autovalida: em evento `pull_request` o GitHub usa o workflow do commit de merge, então ele roda já com o `lint.yml` corrigido. Se os checks ficarem verdes, a correção está provada por ela mesma.

Toca `wireframes/lp-final.html` e `.github/workflows/lint.yml`. **Não toca `index.html`**, de propósito, para não conflitar com o #31.