### PR TITLE
conteudo(idf): metricas do IDF-BR com fonte, no lugar dos marcadores

### DIFF
--- a/wireframes/lp-final.html
+++ b/wireframes/lp-final.html
@@ -237,6 +237,7 @@
   .metric::before { content: ''; display: block; width: 28px; height: 3px; background: var(--on-dark); margin-bottom: 11px; }
   .metric-value { font-family: var(--f-display); font-weight: 700; font-size: clamp(1.2rem, 2vw, 1.6rem); letter-spacing: -0.02em; color: var(--paper); line-height: 1.1; display: block; }
   .metric-label { font-size: 0.78rem; color: var(--on-dark); margin-top: 5px; display: block; }
+  .metrics-source { grid-column: 1 / -1; margin: 0; font-size: 0.72rem; line-height: 1.45; color: var(--on-dark); }
   
   .idf-flow { margin: 32px 0; font-family: var(--f-mono); font-size: 0.75rem; font-weight: 600; color: var(--paper); padding: 0; list-style: none; display: flex; flex-wrap: wrap; gap: 12px; }
   .idf-flow li { display: flex; align-items: center; gap: 12px; }
@@ -982,22 +983,25 @@
 
     <div class="metrics" data-reveal>
       <div class="metric">
-        <span class="i18n metric-value" lang="pt">[ MÉTRICA A VERIFICAR ]</span>
-<span class="i18n metric-value" lang="en">[ VERIFIED METRIC REQUIRED ]</span>
-        <span class="i18n metric-label" lang="pt">Estações e equações processadas</span><span class="i18n metric-label" lang="en">Gauges &amp; equations processed</span>
+        <span class="i18n metric-value" lang="pt">1.543</span>
+<span class="i18n metric-value" lang="en">1,543</span>
+        <span class="i18n metric-label" lang="pt">Usuários ativos</span>
+<span class="i18n metric-label" lang="en">Active users</span>
       </div>
       <div class="metric">
-        <span class="i18n metric-value" lang="pt">[ MÉTRICA A VERIFICAR ]</span>
-<span class="i18n metric-value" lang="en">[ VERIFIED METRIC REQUIRED ]</span>
-        <span class="i18n metric-label" lang="pt">Resposta de cálculo instantânea</span>
-<span class="i18n metric-label" lang="en">Instant calculation response</span>
+        <span class="i18n metric-value" lang="pt">+2.000</span>
+<span class="i18n metric-value" lang="en">+2,000</span>
+        <span class="i18n metric-label" lang="pt">Acessos, vindos de 16 países</span>
+<span class="i18n metric-label" lang="en">Visits, from 16 countries</span>
       </div>
       <div class="metric">
-        <span class="i18n metric-value" lang="pt">[ MÉTRICA A VERIFICAR ]</span>
-<span class="i18n metric-value" lang="en">[ VERIFIED METRIC REQUIRED ]</span>
-        <span class="i18n metric-label" lang="pt">Unidades federativas cobertas</span>
-<span class="i18n metric-label" lang="en">Federative units covered</span>
+        <span class="i18n metric-value" lang="pt">+12 mil</span>
+<span class="i18n metric-value" lang="en">+12k</span>
+        <span class="i18n metric-label" lang="pt">Interações na plataforma</span>
+<span class="i18n metric-label" lang="en">Interactions on the platform</span>
       </div>
+      <p class="i18n metrics-source" lang="pt">Primeiro mês no ar (28 dias), conforme divulgado pelo projeto IDF-BR.</p>
+<p class="i18n metrics-source" lang="en">First month live (28 days), as published by the IDF-BR project.</p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Fecha #19.

As três métricas foram **confirmadas com fonte**, não removidas. A regra da issue era "confirmar com fonte, ou remover — não existe terceira opção". A fonte apareceu, então elas ficam.

## As métricas e a fonte de cada uma

**Fonte:** anúncio "1 mês de IDF-BR no ar", publicado pelo próprio projeto IDF-BR. Janela: **02/02 a 01/03, 28 dias**.

| valor PT | valor EN | rótulo | de onde vem |
|---|---|---|---|
| `1.543` | `1,543` | Usuários ativos | número destacado no card 1 do carrossel do anúncio |
| `+2.000` | `+2,000` | Acessos, vindos de 16 países | cards 1 e 2 do anúncio: "+2000 ACESSOS" e "16 PAÍSES" |
| `+12 mil` | `+12k` | Interações na plataforma | corpo do anúncio: "Mais de 12 mil interações na plataforma" |

Abaixo do bloco entra uma nota de fonte, nas duas línguas:

> Primeiro mês no ar (28 dias), conforme divulgado pelo projeto IDF-BR.
> First month live (28 days), as published by the IDF-BR project.

## O que saiu, e por quê

O slot do meio era `<100ms` — "resposta de cálculo instantânea". **Não voltou como número de performance.** Número de performance é categoria proibida pelo BRIEF seção 3, e não existe benchmark que o sustente. O slot foi ocupado pela métrica de interações, que tem fonte.

Os valores inventados originais, para registro: `5,000+`, `<100ms`, `27`.

## Decisões de precisão que valem revisão

- **A janela entra como "(28 dias)", sem datas.** `1.543 usuários ativos` sem janela é um número contestável. Mas a regra do BRIEF é que janeiro/2026 é a única data factual permitida na página, então "02/02 a 01/03" ficaria fora da regra. "Primeiro mês no ar (28 dias)" dá a janela sem gastar uma data.
- **`acessos` virou `visits` em EN, não `sessions`.** O anúncio diz "acessos" e não declara se a origem no GA4 é sessão ou pageview. Não especifiquei além do que a fonte diz.
- **Ficaram fora os ≈89% do Brasil e a lista dos 15 países.** São três slots; escolhi os três que o próprio anúncio destacou nos cards.

## Layout

A grade segue com 3 colunas — nenhuma mudança de densidade ou hierarquia na laje flagship. A nota de fonte usa `grid-column: 1 / -1` para ocupar a linha inteira, e herda o `gap` do próprio grid em vez de inventar um espaçamento novo.

Uma regra de CSS nova, uma linha:

```css
.metrics-source { grid-column: 1 / -1; margin: 0; font-size: 0.72rem; line-height: 1.45; color: var(--on-dark); }
```

## Verificação

Rodada local, não reportada de memória:

| gate | resultado |
|---|---|
| **Aceite da issue** — marcador de métrica na página | **zero ocorrências** ✅ |
| `content-rules` regra 2 (métrica não verificada) | ✅ |
| `i18n` paridade PT/EN | 156 / 156 ✅ (era 155/155; o par novo entrou balanceado) |
| `lint` stylelint, glob completo do CI | limpo ✅ |
| `lint` html-validate | 41 erros, **idênticos aos de `develop`** — nenhum novo, nenhum na região alterada ✅ |
| Lighthouse acessibilidade | **100** ✅ |
| Lighthouse SEO | **100** ✅ |
| Lighthouse `color-contrast` | **pass** ✅ — a nota usa `--on-dark` sobre `--charcoal`, 6,9:1 |
| Navegador real, 390 / 1440 / 2560px, PT e EN | conferido, sem overflow horizontal ✅ |

### Dois checks seguem vermelhos, por escopo de outras issues

Não são desta mudança e já estavam vermelhos em `develop`:

- `content-rules` **regra 1**: 10 `href="#"` (wordmark, CV, LinkedIn, GitHub, footer-top).
- `content-rules` **regra 3**: 22 molduras de asset vazias.
- `lighthouse` best-practices **96**: um único 404 de `/favicon.ico`, que a página não declara. Talvez valha uma issue própria.

## Checklist de papel (o que o CI não verifica)

- [x] Nenhuma frase nova atribui ao Augusto desenvolvimento do DVO.
- [x] Nenhuma frase nova atribui liderança de design da Ciere.
- [x] Nenhuma frase nova chama o Quantum ML de paper publicado.
- [x] Nenhuma frase nova afirma IA de previsão de enchentes em produção no NIP.
- [x] As métricas são de **adoção da plataforma**, publicadas pelo projeto — não são atribuídas a autoria pessoal.

## Anexo: uma segunda família de números com fonte, que não cabia nos três slots

Contando direto os arquivos de dados publicados em `idf-br.com.br` (base64 → JSON, baixados e contados nesta apuração):

- **Clima atual** (`/assets/json_saida_atual/IDF_clima_atual_IDF.txt`): **3.225** estações Hidroweb distintas, **3.225** equações IDF, **2.062** municípios, **27** UFs.
- **Clima futuro** (`/assets/txt_saida_futuro/idf_<modelo>_<cenário>_<período>.txt`): **35** arquivos, todos existentes, **472.703** equações somadas, **27** UFs em cada um. A grade varia por modelo (2.788 a 17.764 pontos) — não dá para extrapolar de um arquivo para os outros.
- **Total: 475.928 equações IDF.** Modelos: HADGEM2-ES, BESM, CANESM2-ES, MIROC5 + Ensemble.

É contagem reproduzível e serviria nos pills dos data-cards ou na narrativa da laje. Fora do escopo desta issue — fica registrado aqui para não perder a apuração.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
