### PR TITLE
feat(secao): contato e footer com destinos reais e download do CV (#16)

### DIFF
--- a/wireframes/lp-final.html
+++ b/wireframes/lp-final.html
@@ -1341,6 +1341,7 @@
         <h3 class="i18n" lang="pt">Contato</h3><h3 class="i18n" lang="en">Contact</h3>
         <ul>
           <li><a href="mailto:adcmenchaca@inf.ufpel.edu.br" class="i18n" lang="pt">E-mail</a><a href="mailto:adcmenchaca@inf.ufpel.edu.br" class="i18n" lang="en">Email</a></li>
+          <li><a href="tel:+5553999011310">(53)&nbsp;99901&#8209;1310</a></li>
           <li><a href="https://linkedin.com/in/augusto-menchaca-078469330" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
           <li><a href="https://github.com/AugustoMenchaca" target="_blank" rel="noopener noreferrer">GitHub</a></li>
           <li><a href="../curriculo/augusto-menchaca-cv.pdf" download>CV</a></li>

--- a/wireframes/lp-final.html
+++ b/wireframes/lp-final.html
@@ -686,7 +686,7 @@
 <nav class="site-nav">
   <div class="container">
     <div class="nav-row-1">
-      <a href="#" class="wordmark">AUGUSTO MENCHACA</a>
+      <a href="#top" class="wordmark">AUGUSTO MENCHACA</a>
       <div style="display:flex; align-items:center;">
         <a href="#contact" class="btn"><span class="i18n" lang="pt">VAMOS CONVERSAR ↗</span><span class="i18n" lang="en">LET'S TALK ↗</span></a>
         <div class="lang-toggle" style="display:inline-flex; align-items:center; gap:4px; margin-left:16px;">
@@ -706,7 +706,7 @@
 <a href="#experience" class="i18n" lang="en">EXPERIENCE</a>
         <a href="#about" class="i18n" lang="pt">SOBRE</a>
 <a href="#about" class="i18n" lang="en">ABOUT</a>
-        <a href="#"><!-- URL a confirmar -->CV</a>
+        <a href="../curriculo/augusto-menchaca-cv.pdf" download>CV</a>
       </div>
     </div>
   </div>
@@ -714,7 +714,7 @@
 
 <main>
 <!-- HERO -->
-<header class="hero">
+<header class="hero" id="top">
   <div class="container">
     <div class="hero-top">
       <div>
@@ -1311,9 +1311,9 @@
       <div class="contact-links">
         <a href="mailto:adcmenchaca@inf.ufpel.edu.br" class="i18n btn round" lang="pt"><span class="ico" aria-hidden="true">✉</span>E-MAIL</a>
         <a href="mailto:adcmenchaca@inf.ufpel.edu.br" class="i18n btn round" lang="en"><span class="ico" aria-hidden="true">✉</span>EMAIL</a>
-        <a href="#" class="btn ghost round"><span class="ico" aria-hidden="true">↗</span>LINKEDIN</a><!-- URL a confirmar -->
-        <a href="#" class="btn ghost round"><span class="ico" aria-hidden="true">↗</span>GITHUB</a><!-- URL a confirmar -->
-        <a href="#" class="btn ghost round"><span class="ico" aria-hidden="true">↗</span>CV</a><!-- URL a confirmar -->
+        <a href="https://linkedin.com/in/augusto-menchaca-078469330" class="btn ghost round" target="_blank" rel="noopener noreferrer"><span class="ico" aria-hidden="true">↗</span>LINKEDIN</a>
+        <a href="https://github.com/AugustoMenchaca" class="btn ghost round" target="_blank" rel="noopener noreferrer"><span class="ico" aria-hidden="true">↗</span>GITHUB</a>
+        <a href="../curriculo/augusto-menchaca-cv.pdf" class="btn ghost round" download><span class="ico" aria-hidden="true">↗</span>CV</a>
       </div>
     </div>
   </div>
@@ -1341,13 +1341,13 @@
         <h3 class="i18n" lang="pt">Contato</h3><h3 class="i18n" lang="en">Contact</h3>
         <ul>
           <li><a href="mailto:adcmenchaca@inf.ufpel.edu.br" class="i18n" lang="pt">E-mail</a><a href="mailto:adcmenchaca@inf.ufpel.edu.br" class="i18n" lang="en">Email</a></li>
-          <li><a href="#">LinkedIn</a></li><!-- URL a confirmar -->
-          <li><a href="#">GitHub</a></li><!-- URL a confirmar -->
-          <li><a href="#">CV</a></li><!-- URL a confirmar -->
+          <li><a href="https://linkedin.com/in/augusto-menchaca-078469330" target="_blank" rel="noopener noreferrer">LinkedIn</a></li>
+          <li><a href="https://github.com/AugustoMenchaca" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+          <li><a href="../curriculo/augusto-menchaca-cv.pdf" download>CV</a></li>
         </ul>
       </div>
-      <a href="#" class="i18n footer-top" lang="pt"><span aria-hidden="true">↑</span>Topo</a>
-      <a href="#" class="i18n footer-top" lang="en"><span aria-hidden="true">↑</span>Top</a>
+      <a href="#top" class="i18n footer-top" lang="pt"><span aria-hidden="true">↑</span>Topo</a>
+      <a href="#top" class="i18n footer-top" lang="en"><span aria-hidden="true">↑</span>Top</a>
     </div>
 
     <div class="footer-wordmark" aria-hidden="true">AUGUSTO</div>


### PR DESCRIPTION
Resolve #16.

## O que muda

- **Eliminação de links mortos:** substituídas todas as 10 ocorrências de `href="#"` mapeadas pelo CI em `wireframes/lp-final.html`.
- **Navegação de retorno ao topo:**
  - Adicionado `id="top"` na `<header class="hero">`.
  - Wordmark (`AUGUSTO MENCHACA`) e botões do footer (`Topo` / `Top`) apontam para `#top`.
- **Currículo compilado:**
  - Links da navbar, do botão de contato e da lista do footer apontam para `../curriculo/augusto-menchaca-cv.pdf` com atributo `download`.
- **Redes sociais e contato:**
  - Botões e links de LinkedIn e GitHub apontam para os perfis reais, com `target="_blank"` e `rel="noopener noreferrer"`.
  - **Telefone** `(53) 99901-1310` com `href="tel:+5553999011310"`, na coluna **Contato** do rodapé — commit b9eca11, em resposta à revisão.
- **Limpeza:**
  - Removidos os 6 comentários `<!-- URL a confirmar -->`.

## O telefone: onde entrou e por quê

A revisão apontou corretamente que o commit ff81cf0 não tinha nenhuma ocorrência do número nem link `tel:`. Uma linha, no rodapé:

```html
<li><a href="tel:+5553999011310">(53)&nbsp;99901&#8209;1310</a></li>
```

**Por que o rodapé, e não o painel da seção 06.** A coluna `Contato` do rodapé já é exatamente a lista de canais que a issue enumera — E-mail, LinkedIn, GitHub, CV. O telefone era o membro ausente desse conjunto, então completá-lo ali cabe em uma linha e não mexe em layout. O painel `.contact-links` da seção 06 é um grid `1fr 1fr`: um quinto botão deixaria uma célula órfã em 1440 e 2560px.

**Por que o texto visível é o próprio número, sem par PT/EN.** Dígito não tem idioma — mesma decisão já tomada para LinkedIn, GitHub e CV. Expor o número em vez de um rótulo "Telefone / Phone" também é o que a revisão pediu, e deixa o número copiável a olho. A paridade i18n do CI continua equilibrada.

**Por que `&nbsp;` e `&#8209;`.** Não é enfeite. A regra `tel-non-breaking` do `html-validate` reprova espaço e hífen comuns dentro de um `tel:`; com os caracteres normais a contagem subia de **33 para 35** e a catraca reprovava o PR. Com eles, o número também deixa de poder quebrar no meio da linha.

## Verificações

**No CI desta branch** — [lint `34068057709`](https://github.com/AugustoMenchaca/AugustoMenchaca.github.io/actions/runs/34068057709) e [lighthouse `34068057711`](https://github.com/AugustoMenchaca/AugustoMenchaca.github.io/actions/runs/34068057711), os cinco checks verdes:

| check | base `develop` | neste PR | veredito do CI |
|---|---|---|---|
| `html-validate` (catraca) | 33 erros | **33 erros** | zero regressão |
| `content-rules` (catraca) | 32 violações | **22 violações** | `O PR REMOVE 10 violacao(oes). De 32 para 22.` |
| `stylelint` | — | **sem erro** | passa |
| Paridade PT/EN | — | **149 / 149** | equilibrada |

`Orcamento de qualidade aprovado`:

| categoria | orçamento | medido no CI |
|---|---|---|
| Acessibilidade | 100 | **100** |
| Best Practices | 100 | **100** |
| SEO | 100 | **100** |
| Performance | ≥ 90 (warn) | **99** |

**Localmente, servindo a página em `http://127.0.0.1:8777`**, para checar o que o CI não olha:

- Asserções duras individuais do `lighthouserc.json`: `color-contrast` 1, `link-name` 1, `button-name` 1, `heading-order` 1, `html-has-lang` 1, `meta-viewport` 1, `total-byte-weight` 194 569 B (teto 2 500 000), `cumulative-layout-shift` 0,0006 (teto 0,1).
- **Revisão visual em navegador, 390 / 1440 / 2560px, em PT e em EN:** o telefone renderiza em uma linha só, sem quebra e sem overflow horizontal (`scrollWidth` 375 / 1425 / 2545 contra viewport 390 / 1440 / 2560). O hífen não-separável renderiza como hífen normal na Inter — sem tofu. O item aparece nos dois idiomas, como esperado para uma string sem par. Zero erro e zero aviso no console.
- **Download do CV:** `../curriculo/augusto-menchaca-cv.pdf` a partir de `wireframes/lp-final.html` responde `200 application/pdf`, 25 219 bytes — o mesmo tamanho do arquivo versionado.

> Nota sobre os números: rodadas locais em Git Bash no Windows contam 41 → 31 em `content-rules` e 155/155 em i18n, contra 32 → 22 e 149/149 no Ubuntu do CI. A diferença é de `grep` e locale, não de conteúdo: a variação (−10) e o equilíbrio PT/EN são idênticos nos dois. Os números da tabela acima são os do CI, que é o portão de verdade.

## Fora de escopo, deliberadamente

- `index.html` não foi tocado — o `CONTRIBUTING.md` diz que ele não é o produto em construção.
- `label-content-name-mismatch` continua sendo a única auditoria reprovada no Lighthouse. É o botão de pausa do carrossel (`rail-pause-btn`), peso 0, pré-existente e alheio a esta issue. A acessibilidade segue em 100.

## Checklist de conteúdo

- [x] Nenhuma afirmação nova: o único texto adicionado é o número de telefone que a própria issue #16 especifica.
- [x] Nenhuma frase atribui a ele desenvolvimento do DVO, liderança de design da Ciere, publicação do Quantum ML ou IA de previsão de enchentes em produção no NIP.
- [x] Texto novo existe nas duas línguas — ou, como aqui, é neutro de idioma por ser dígito.
