### PR TITLE
fix(pesquisa): caixa alta deterministica, medida com o revelador neutralizado (#46)

### DIFF
--- a/docs/design/PESQUISA-TIPOGRAFIA.md
+++ b/docs/design/PESQUISA-TIPOGRAFIA.md
@@ -224,7 +224,7 @@ A escala mantém cinco degraus funcionais, reancorados nas medições diretas de
 - **Redução auditada de ALL CAPS:** A sonda C6 quantificou a queda de caixa alta na página inteira:
   - A 1440px: queda de **96 para 23 elementos** (**-76,0%**); volume de caracteres reduzido de **1.513 para 467** (**-69,1%**).
   - A 390px: queda de **89 para 23 elementos** (**-74,2%**); volume de caracteres reduzido de **1.419 para 467** (**-67,1%**).
-  - A versão anterior deste arquivo publicava bases de **96 elementos a 1440px** e **89 elementos a 390px**, subcontadas porque o revelador da página escondia 19 dos 25 blocos; os novos totais vêm de um passe com o revelador neutralizado.
+  - A versão anterior deste arquivo publicava bases de **55 elementos a 1440px** e **48 elementos a 390px**, subcontadas porque o revelador da página escondia 19 dos 25 blocos; os novos totais vêm de um passe com o revelador neutralizado.
 
 ---
 

--- a/docs/design/PESQUISA-TIPOGRAFIA.md
+++ b/docs/design/PESQUISA-TIPOGRAFIA.md
@@ -94,7 +94,7 @@ Todas as grandezas desta seção foram extraídas de `medicoes.json` (`referenci
 | `aelixa` | 240px | 6ch | 1,00 (declarada) | 18px | 83ch | 1,50 (declarada) | 13,33× | 7 / 1 | 19 | não |
 | `illoca` | 111px | 14ch | 0,90 (declarada) | 12px | 31ch | 1,00 (declarada) | 9,25× | 121 / 22 | 2 | não |
 | `paulkalkbrenner` | 150px | 13ch | 0,80 (declarada) | 12px | 19ch | 1,00 (declarada) | 12,50× | 51 / 8 | 183 | não |
-| `lxlcreative` | 102px | 9ch | 0,90 (declarada) | 17px | 38ch | 1,44 (declarada) | 6,00× | 14 / 3 | 26 | **sim** |
+| `lxlcreative` | 102px | 9ch | 0,90 (declarada) | 17px | 38ch | 1,44 (declarada) | 6,00× | 14 / 3 | 30 | **sim** |
 | `white-desert` | 320px | 9ch | 0,90 (declarada) | 16px | 36ch | 1,25 (normal-medida) | 20,00× | 9 / 3 | 25 | não |
 
 ### 3.2 Peças rejeitadas pelo cliente — grupo de controle rotulado (n=10)
@@ -224,7 +224,7 @@ A escala mantém cinco degraus funcionais, reancorados nas medições diretas de
 - **Redução auditada de ALL CAPS:** A sonda C6 quantificou a queda de caixa alta na página inteira:
   - A 1440px: queda de **96 para 23 elementos** (**-76,0%**); volume de caracteres reduzido de **1.513 para 467** (**-69,1%**).
   - A 390px: queda de **89 para 23 elementos** (**-74,2%**); volume de caracteres reduzido de **1.419 para 467** (**-67,1%**).
-  - A versão anterior deste arquivo publicava bases de **55 elementos a 1440px** e **48 elementos a 390px**, subcontadas porque o revelador da página escondia 19 dos 25 blocos; os novos totais vêm de um passe com o revelador neutralizado.
+  - A versão anterior deste arquivo publicava bases de **96 elementos a 1440px** e **89 elementos a 390px**, subcontadas porque o revelador da página escondia 19 dos 25 blocos; os novos totais vêm de um passe com o revelador neutralizado.
 
 ---
 
@@ -236,17 +236,17 @@ O "depois" não é uma estimativa nem provém de arquivos de rascunho. Foi medid
 
 | variante / chave | viewport | maior título | razão (wh 13px) | ALL CAPS (nós) | altura | telas | maior texto na página (qualquer tag) | veredito do classificador |
 |---|---|---|---|---|---|---|---|---|
-| **`A-lp-atual@1440`** | 1440×900 | 46px | 3,54× | 55 | 8.374px | 9,3 | 232px (`div.footer-wordmark` @ 95,9%) | **REJEITADO** (46 < 89px; 3,54 < 5,57×) |
-| **`B-so-escala@1440`** | 1440×900 | **144px** | **11,08×** | 13 | 10.604px | 11,8 | 232px (`div.footer-wordmark` @ 96,7%) | **APROVADO** (144 ≥ 89px; 11,08 ≥ 5,57×) |
-| **`C-escala-evento-curto@1440`** | 1440×900 | **144px** | **11,08×** | 13 | 10.169px | 11,3 | 232px (`div.footer-wordmark` @ 96,6%) | **APROVADO** (144 ≥ 89px; 11,08 ≥ 5,57×) |
-| **`A-lp-atual@390`** | 390×844 | 27px | 2,08× | 48 | 11.078px | 13,1 | 73px (`div.footer-wordmark` @ 98,1%) | **REJEITADO** (27 < 89px; 2,08 < 5,57×) |
-| **`B-so-escala@390`** | 390×844 | **48px** | **3,69×** | 13 | 12.444px | 14,7 | 73px (`div.footer-wordmark` @ 98,3%) | **REJEITADO** (48 < 89px; 3,69 < 5,57×) |
-| **`C-escala-evento-curto@390`** | 390×844 | **48px** | **3,69×** | 13 | 12.399px | 14,7 | 73px (`div.footer-wordmark` @ 98,3%) | **REJEITADO** (48 < 89px; 3,69 < 5,57×) |
+| **`A-lp-atual@1440`** | 1440×900 | 46px | 3,54× | 96 | 8.374px | 9,3 | 232px (`div.footer-wordmark` @ 95,9%) | **REJEITADO** (46 < 89px; 3,54 < 5,57×) |
+| **`B-so-escala@1440`** | 1440×900 | **144px** | **11,08×** | 23 | 10.604px | 11,8 | 232px (`div.footer-wordmark` @ 96,7%) | **APROVADO** (144 ≥ 89px; 11,08 ≥ 5,57×) |
+| **`C-escala-evento-curto@1440`** | 1440×900 | **144px** | **11,08×** | 23 | 10.169px | 11,3 | 232px (`div.footer-wordmark` @ 96,6%) | **APROVADO** (144 ≥ 89px; 11,08 ≥ 5,57×) |
+| **`A-lp-atual@390`** | 390×844 | 27px | 2,08× | 89 | 11.078px | 13,1 | 73px (`div.footer-wordmark` @ 98,1%) | **REJEITADO** (27 < 89px; 2,08 < 5,57×) |
+| **`B-so-escala@390`** | 390×844 | **48px** | **3,69×** | 23 | 12.444px | 14,7 | 73px (`div.footer-wordmark` @ 98,3%) | **REJEITADO** (48 < 89px; 3,69 < 5,57×) |
+| **`C-escala-evento-curto@390`** | 390×844 | **48px** | **3,69×** | 23 | 12.399px | 14,7 | 73px (`div.footer-wordmark` @ 98,3%) | **REJEITADO** (48 < 89px; 3,69 < 5,57×) |
 
 ### 8.2 Análise dos achados
 
 1. **B e C são perfeitamente idênticas perante o classificador:** A troca de conteúdo do herói na variante C (substituir o texto do `h1` pelo nome curto em duas linhas e rebaixar a frase para subtítulo) **não contribui com um único pixel nem com qualquer fração de razão** para cruzar o corte (144px e 11,08× nas duas variantes a 1440px; 48px e 3,69× nas duas a 390px). O evento curto apenas diminui a altura em 435px no desktop e 45px no mobile. Como a alteração de copy não tem respaldo em necessidade métrica, trata-se de decisão puramente editorial, remetida ao Gate B/C.
-2. **A 390px a escala tem efeito sensível, porém insuficiente:** A versão reprovada afirmava erroneamente que a escala não surtia "nenhum efeito" a 390px. Os dados corrigidos mostram que ela eleva o título de 27px para 48px (+21px, +77,8%), eleva a razão de 2,08× para 3,69× e reduz ALL CAPS de 48 para 13 nós. No entanto, **48px permanece muito abaixo do limiar de 89px e 3,69× fica abaixo de 5,57×**. O piso do `clamp(3rem, 10vw, 9rem)` crava em 48px porque `10vw` a 390px equivale a 39px. O viewport móvel continua classificado do lado rejeitado, constituindo trabalho em aberto.
+2. **A 390px a escala tem efeito sensível, porém insuficiente:** A versão reprovada afirmava erroneamente que a escala não surtia "nenhum efeito" a 390px. Os dados corrigidos mostram que ela eleva o título de 27px para 48px (+21px, +77,8%), eleva a razão de 2,08× para 3,69× e reduz ALL CAPS de 89 para 23 nós. No entanto, **48px permanece muito abaixo do limiar de 89px e 3,69× fica abaixo de 5,57×**. O piso do `clamp(3rem, 10vw, 9rem)` crava em 48px porque `10vw` a 390px equivale a 39px. O viewport móvel continua classificado do lado rejeitado, constituindo trabalho em aberto.
 3. **Ponto cego do rodapé:** Nas três variantes a 1440px, o maior texto físico renderizado na página inteira é o `<div class="footer-wordmark">` com **232px**, localizado a cerca de 96% de profundidade de rolagem.
 
 ### 8.3 O CSS injetado na íntegra

--- a/docs/design/PESQUISA-TIPOGRAFIA.md
+++ b/docs/design/PESQUISA-TIPOGRAFIA.md
@@ -17,6 +17,8 @@ O `REFERENCE-BOARD-v3` §12 submeteu dez variáveis formais a um teste com **15 
 
 A `wireframes/lp-final.html` original mede **46px** no maior título e razão **3,54×** (com workhorse medido de 13px), classificando-se inequivocamente do lado **rejeitado** nas duas variáveis.
 
+O `REFERENCE-BOARD-v3.md` registra **3,29×** para a mesma página porque usa um workhorse de **14px**; os **3,54×** deste documento usam os **13px** medidos, portanto ambos os resultados estão corretos sob suas respectivas réguas.
+
 Esta issue tem três encargos:
 1. **Validar a sobrevivência dos cortes** após o conserto de três defeitos graves no instrumento de medição;
 2. **Decidir formalmente entre dominância assimétrica e uniformidade**, calculando o custo dessa escolha em altura de página;
@@ -220,8 +222,9 @@ A escala mantém cinco degraus funcionais, reancorados nas medições diretas de
 - **Famílias tipográficas:** Preservadas sem alteração — *Instrument Sans*, *Inter* e *IBM Plex Mono*.
 - **Veto de pesos extremos:** Pesos 800 e 900 permanecem **terminantemente proibidos**. Teto tipográfico fixado em peso 700 (*Bold*).
 - **Redução auditada de ALL CAPS:** A sonda C6 quantificou a queda de caixa alta na página inteira:
-  - A 1440px: queda de **55 para 13 elementos** (redução de 42 elementos, ou **-76,4%**; volume de caracteres reduzido de 854 para 226, **-73,5%**).
-  - A 390px: queda de **48 para 13 elementos** (de 760 para 226 caracteres, **-70,3%**).
+  - A 1440px: queda de **96 para 23 elementos** (**-76,0%**); volume de caracteres reduzido de **1.513 para 467** (**-69,1%**).
+  - A 390px: queda de **89 para 23 elementos** (**-74,2%**); volume de caracteres reduzido de **1.419 para 467** (**-67,1%**).
+  - A versão anterior deste arquivo publicava bases de **55 elementos a 1440px** e **48 elementos a 390px**, subcontadas porque o revelador da página escondia 19 dos 25 blocos; os novos totais vêm de um passe com o revelador neutralizado.
 
 ---
 
@@ -282,6 +285,8 @@ A variante C acrescentou a essa folha a execução do script `JS_EVENTO_CURTO`, 
 ### 9.1 Limites operacionais do instrumento
 
 - **Inviabilidade de medição headless para páginas animadas:** Ficou comprovado que o Chromium em modo headless desativa pipelines essenciais de renderização quando interage com bibliotecas de scroll e WebGL, congelando animações em opacidade zero (`illoca.unseen.co`). A execução em janela real (`--headed`) com janelas temporais espaçadas é mandatória para a reprodutibilidade dos dados.
+- **Caixa alta exige o revelador neutralizado:** A varredura de 700px com pausa de 90ms revela 6 dos 25 blocos `[data-reveal]`; sem neutralizar, a contagem depende de qual bloco a corrida alcançou. O passe neutralizado mede o estado assentado da página, correspondente a “caixa alta na página inteira”. A origem é reproduzível com `SONDA_DIAG=1 node docs/design/tipografia/medir.mjs --so-local --headed`, que imprime `dataReveal` e `revealed` por amostra.
+- **Altura não determinística da Variante A em desktop:** Duas execuções do comando gravado em `_meta.comando` devolveram **8.350px** e **8.374px** para `A-lp-atual@1440`. A oscilação não está resolvida nesta issue; por isso, o custo de altura publicado no §8 (**+2.230px, +26,6%**) carrega incerteza de **±24px** na base.
 - **O wordmark de rodapé não substitui a hierarquia:** O `<div class="footer-wordmark">` de 232px da LP localiza-se a 95,9% de rolagem. O `aelixa.webflow.io` (aprovado) possui idêntica estrutura: um elemento de **240px a 97,8%** de profundidade. A presença de uma palavra gigante no encerramento da página aparece nos dois lados do espectro e **não separa aprovação de rejeição**. O que separa os grupos é a escala que governa os títulos de conteúdo ativo (102–320px vs 20–76px).
 
 ### 9.2 O que continua estritamente não medido
@@ -301,7 +306,7 @@ A variante C acrescentou a essa folha a execução do script `JS_EVENTO_CURTO`, 
 1. Adoção da **dominância assimétrica** sobre a uniformidade, única rota que satisfaz os limiares de 89px e 5,57×;
 2. Estabelecimento da escala de cinco degraus (**144 / 72 / 32 / 16 / 12px**), ancorando cada valor em precedentes aprovados de `medicoes.json`;
 3. Serifa no display descartada como requisito obrigatório (apenas 1 de 5 aprovadas utiliza serifa no maior título);
-4. Redução auditada de ALL CAPS na página inteira (-76,4% a 1440px e -70,3% a 390px);
+4. Redução auditada de ALL CAPS na página inteira: elementos **-76,0% a 1440px** e **-74,2% a 390px**; caracteres **-69,1% a 1440px** e **-67,1% a 390px**;
 5. Extinção definitiva de arquivos de protótipo de escala (`escala-proposta-*`), adotando-se a injeção em tempo de medição como metodologia de aferição.
 
 **QUESTÕES ABERTAS:**

--- a/docs/design/tipografia/medicoes.json
+++ b/docs/design/tipografia/medicoes.json
@@ -8,6 +8,7 @@
     "sonda": "docs/design/tipografia/sonda-tipografia.mjs",
     "alvos": "docs/design/tipografia/alvos.json",
     "nota": "Nao ha arquivo de prototipo. O \"depois\" da escala e medido por injecao de CSS sobre a wireframes/lp-final.html real. Ver provenance.md P-015.",
+    "notaCaixaAlta": "caixaAlta.semNeutralizar NAO e numero citavel: e a contagem sem neutralizar o revelador, ou seja, a propria grandeza nao deterministica que a issue #46 conserta, e varia entre rodadas. Existe so para dimensionar quanto o revelador escondia. O numero valido e caixaAlta.elementos, medido no passe neutralizado.",
     "total": 24,
     "sucessos": 24,
     "falhas": []

--- a/docs/design/tipografia/medicoes.json
+++ b/docs/design/tipografia/medicoes.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "gerado": "2026-09-08T02:14:15.248Z",
+    "gerado": "2026-09-10T17:46:17.112Z",
     "comando": "node docs/design/tipografia/medir.mjs --headed",
     "comandoOficial": "node docs/design/tipografia/medir.mjs --headed",
     "modo": "headed",
@@ -15,7 +15,7 @@
   "referencias": {
     "aelixa": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:14:30.403Z",
+      "dataHora": "2026-09-10T17:46:30.942Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 17502,
@@ -411,7 +411,10 @@
         "caixaAlta": {
           "elementos": 19,
           "caracteresTotais": 357,
-          "caracteresPor1000px": 20.4
+          "caracteresPor1000px": 20.4,
+          "semNeutralizar": 19,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -516,7 +519,7 @@
     },
     "illoca": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:14:43.760Z",
+      "dataHora": "2026-09-10T17:46:43.316Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 900,
@@ -809,7 +812,10 @@
         "caixaAlta": {
           "elementos": 2,
           "caracteresTotais": 11,
-          "caracteresPor1000px": 12.22
+          "caracteresPor1000px": 12.22,
+          "semNeutralizar": 2,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -910,16 +916,16 @@
     },
     "paulkalkbrenner": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:15:03.935Z",
+      "dataHora": "2026-09-10T17:47:00.915Z",
       "viewport": "1440x900x1",
       "rolagem": {
-        "altura": 10711,
+        "altura": 10709,
         "imgs": 83,
-        "carregadas": 66
+        "carregadas": 67
       },
       "data": {
         "url": "https://www.paulkalkbrenner.net/",
-        "altura": 10711,
+        "altura": 10709,
         "fontes": {
           "status": "loaded",
           "carregadas": 2
@@ -1031,7 +1037,7 @@
         ],
         "workhorse": {
           "px": 12,
-          "ocorrencias": 24
+          "ocorrencias": 23
         },
         "razaoTituloWorkhorse": 12.5,
         "titulosDetalhes": [
@@ -1213,12 +1219,15 @@
         "caixaAlta": {
           "elementos": 183,
           "caracteresTotais": 798,
-          "caracteresPor1000px": 74.5
+          "caracteresPor1000px": 74.52,
+          "semNeutralizar": 183,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
             "familia": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
-            "contagem": 57
+            "contagem": 56
           }
         ],
         "maiorTextoRenderizado": {
@@ -1298,7 +1307,7 @@
     },
     "lxlcreative": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:15:24.740Z",
+      "dataHora": "2026-09-10T17:47:19.585Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 15323,
@@ -1667,9 +1676,12 @@
           "porRecorte": []
         },
         "caixaAlta": {
-          "elementos": 26,
-          "caracteresTotais": 656,
-          "caracteresPor1000px": 42.81
+          "elementos": 30,
+          "caracteresTotais": 1159,
+          "caracteresPor1000px": 75.64,
+          "semNeutralizar": 26,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -1777,7 +1789,7 @@
     },
     "white-desert": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:15:41.129Z",
+      "dataHora": "2026-09-10T17:47:35.808Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 20787,
@@ -2168,7 +2180,10 @@
         "caixaAlta": {
           "elementos": 25,
           "caracteresTotais": 509,
-          "caracteresPor1000px": 24.49
+          "caracteresPor1000px": 24.49,
+          "semNeutralizar": 25,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -2280,12 +2295,12 @@
     },
     "charityshot": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:15:51.416Z",
+      "dataHora": "2026-09-10T17:47:46.650Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 900,
         "imgs": 73,
-        "carregadas": 44
+        "carregadas": 46
       },
       "data": {
         "url": "https://charityshot.co.uk/",
@@ -2426,7 +2441,10 @@
         "caixaAlta": {
           "elementos": 6,
           "caracteresTotais": 41,
-          "caracteresPor1000px": 45.56
+          "caracteresPor1000px": 45.56,
+          "semNeutralizar": 6,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -2496,16 +2514,16 @@
     },
     "obspogon": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:16:06.571Z",
+      "dataHora": "2026-09-10T17:48:03.196Z",
       "viewport": "1440x900x1",
       "rolagem": {
-        "altura": 2986,
-        "imgs": 32,
-        "carregadas": 30
+        "altura": 3061,
+        "imgs": 33,
+        "carregadas": 31
       },
       "data": {
         "url": "https://obspogon.neocities.org/",
-        "altura": 2986,
+        "altura": 3061,
         "fontes": {
           "status": "loaded",
           "carregadas": 24
@@ -2515,17 +2533,17 @@
           "h": 900,
           "dpr": 1
         },
-        "telas": 3.3,
-        "telas_base900_legado": 3.3,
-        "metricaV2_hsvS015": 0.9,
-        "corPerceptivel_C005": 0.9,
-        "corForte_C012": 0.8,
-        "cromaMedioPonderado": 0.002,
+        "telas": 3.4,
+        "telas_base900_legado": 3.4,
+        "metricaV2_hsvS015": 1.7,
+        "corPerceptivel_C005": 1.7,
+        "corForte_C012": 0.7,
+        "cromaMedioPonderado": 0.003,
         "cromaPicoOklch": 0.177,
         "fundos": [
           {
             "cor": "rgb(0,0,0)",
-            "pct": 97.3,
+            "pct": 96.6,
             "L": 0,
             "C": 0,
             "H": 0
@@ -2538,8 +2556,15 @@
             "H": 102
           },
           {
-            "cor": "rgb(0,128,0)",
+            "cor": "rgb(121,190,242)",
             "pct": 0.8,
+            "L": 0.78,
+            "C": 0.102,
+            "H": 242
+          },
+          {
+            "cor": "rgb(0,128,0)",
+            "pct": 0.7,
             "L": 0.52,
             "C": 0.177,
             "H": 142
@@ -2553,12 +2578,12 @@
           }
         ],
         "midia": {
-          "img": 32,
+          "img": 33,
           "svg": 0,
           "video": 0,
           "canvas": 0
         },
-        "midiaTotalPor1000": 10.72,
+        "midiaTotalPor1000": 10.78,
         "keyframes": 7,
         "nomes": [
           "fa-beat",
@@ -2569,10 +2594,10 @@
           "fa-shake",
           "fa-spin"
         ],
-        "keyframesPor1000": 2.34,
-        "folhasBloqueadas": 0,
+        "keyframesPor1000": 2.29,
+        "folhasBloqueadas": 1,
         "emTransicao": 72,
-        "emTransicaoPor1000": 24.11,
+        "emTransicaoPor1000": 23.52,
         "animacoesAtivas": 2,
         "duracoes": [
           [
@@ -2585,7 +2610,7 @@
         ],
         "workhorse": {
           "px": 16,
-          "ocorrencias": 15
+          "ocorrencias": 16
         },
         "razaoTituloWorkhorse": 2,
         "titulosDetalhes": [
@@ -2634,7 +2659,7 @@
           ],
           "workhorse_semFiltro": {
             "px": 16,
-            "ocorrencias": 15
+            "ocorrencias": 16
           },
           "razao_semFiltro": 2,
           "divergeDoCorrigido": false
@@ -2646,7 +2671,10 @@
         "caixaAlta": {
           "elementos": 0,
           "caracteresTotais": 0,
-          "caracteresPor1000px": 0
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -2655,6 +2683,10 @@
           },
           {
             "familia": "monospace",
+            "contagem": 1
+          },
+          {
+            "familia": "\"Open Sans\", sans-serif",
             "contagem": 1
           }
         ],
@@ -2671,7 +2703,7 @@
           "fontWeight": "700",
           "textTransform": "none",
           "fracaoContida": 1,
-          "profundidadeDeRolagem": 2.4
+          "profundidadeDeRolagem": 2.3
         },
         "pontoCego": false,
         "diferencaPx": 0,
@@ -2720,7 +2752,7 @@
     },
     "paulfragara": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:16:16.894Z",
+      "dataHora": "2026-09-10T17:48:13.682Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 1431,
@@ -2905,7 +2937,10 @@
         "caixaAlta": {
           "elementos": 0,
           "caracteresTotais": 0,
-          "caracteresPor1000px": 0
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -2992,7 +3027,7 @@
     },
     "lowmess": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:16:27.004Z",
+      "dataHora": "2026-09-10T17:48:24.814Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 1234,
@@ -3179,7 +3214,10 @@
         "caixaAlta": {
           "elementos": 0,
           "caracteresTotais": 0,
-          "caracteresPor1000px": 0
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -3263,16 +3301,16 @@
     },
     "simonbetton": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:16:38.906Z",
+      "dataHora": "2026-09-10T17:48:37.357Z",
       "viewport": "1440x900x1",
       "rolagem": {
-        "altura": 9277,
+        "altura": 9298,
         "imgs": 14,
         "carregadas": 5
       },
       "data": {
         "url": "https://www.simonbetton.com/",
-        "altura": 9277,
+        "altura": 9298,
         "fontes": {
           "status": "loaded",
           "carregadas": 4
@@ -3300,28 +3338,32 @@
         ],
         "midia": {
           "img": 14,
-          "svg": 20,
+          "svg": 23,
           "video": 0,
           "canvas": 1
         },
-        "midiaTotalPor1000": 3.77,
-        "keyframes": 10,
+        "midiaTotalPor1000": 4.09,
+        "keyframes": 14,
         "nomes": [
+          "aui-pulse",
           "work-card-parallax",
           "spin",
           "pulse",
           "enter",
           "exit",
+          "collapsible-down",
+          "collapsible-up",
+          "tw-shimmer",
           "profile-bounce",
           "profile-fade",
           "mobile-profile-tab-nav-enter",
           "route-content-out",
           "route-content-in"
         ],
-        "keyframesPor1000": 1.08,
+        "keyframesPor1000": 1.51,
         "folhasBloqueadas": 0,
-        "emTransicao": 90,
-        "emTransicaoPor1000": 9.7,
+        "emTransicao": 96,
+        "emTransicaoPor1000": 10.32,
         "animacoesAtivas": 15,
         "duracoes": [
           [
@@ -3338,7 +3380,7 @@
           ],
           [
             "0.15s",
-            8
+            9
           ],
           [
             "0.1s",
@@ -3346,14 +3388,14 @@
           ],
           [
             "0.2s",
+            4
+          ],
+          [
+            "0.125s",
             2
           ],
           [
             "0.3s",
-            1
-          ],
-          [
-            "0.225s",
             1
           ]
         ],
@@ -3517,7 +3559,10 @@
         "caixaAlta": {
           "elementos": 0,
           "caracteresTotais": 0,
-          "caracteresPor1000px": 0
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -3538,7 +3583,7 @@
           "fontWeight": "500",
           "textTransform": "none",
           "fracaoContida": 1,
-          "profundidadeDeRolagem": 1.6
+          "profundidadeDeRolagem": 1.5
         },
         "pontoCego": false,
         "diferencaPx": 0,
@@ -3602,7 +3647,7 @@
     },
     "nextfive": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:16:50.309Z",
+      "dataHora": "2026-09-10T17:48:49.088Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 2915,
@@ -3840,7 +3885,10 @@
         "caixaAlta": {
           "elementos": 0,
           "caracteresTotais": 0,
-          "caracteresPor1000px": 0
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -3929,7 +3977,7 @@
     },
     "incomescrane": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:17:01.882Z",
+      "dataHora": "2026-09-10T17:49:00.689Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 4056,
@@ -4077,7 +4125,10 @@
         "caixaAlta": {
           "elementos": 4,
           "caracteresTotais": 25,
-          "caracteresPor1000px": 6.16
+          "caracteresPor1000px": 6.16,
+          "semNeutralizar": 4,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -4147,7 +4198,7 @@
     },
     "shelomoh": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:17:13.368Z",
+      "dataHora": "2026-09-10T17:49:12.389Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 2364,
@@ -4329,7 +4380,10 @@
         "caixaAlta": {
           "elementos": 34,
           "caracteresTotais": 563,
-          "caracteresPor1000px": 238.16
+          "caracteresPor1000px": 238.16,
+          "semNeutralizar": 34,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -4404,7 +4458,7 @@
     },
     "thatmlopsguy": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:17:23.822Z",
+      "dataHora": "2026-09-10T17:49:23.215Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 3602,
@@ -4680,7 +4734,10 @@
         "caixaAlta": {
           "elementos": 8,
           "caracteresTotais": 92,
-          "caracteresPor1000px": 25.54
+          "caracteresPor1000px": 25.54,
+          "semNeutralizar": 8,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -4770,7 +4827,7 @@
     },
     "cassidoo": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:17:34.280Z",
+      "dataHora": "2026-09-10T17:49:37.234Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 1654,
@@ -4947,7 +5004,10 @@
         "caixaAlta": {
           "elementos": 0,
           "caracteresTotais": 0,
-          "caracteresPor1000px": 0
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -5027,7 +5087,7 @@
     },
     "ciere": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:17:45.640Z",
+      "dataHora": "2026-09-10T17:49:48.589Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 6297,
@@ -5345,7 +5405,10 @@
         "caixaAlta": {
           "elementos": 13,
           "caracteresTotais": 259,
-          "caracteresPor1000px": 41.13
+          "caracteresPor1000px": 41.13,
+          "semNeutralizar": 13,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -5452,7 +5515,7 @@
     },
     "idf-br": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:17:56.217Z",
+      "dataHora": "2026-09-10T17:49:59.337Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 929,
@@ -5660,7 +5723,10 @@
         "caixaAlta": {
           "elementos": 0,
           "caracteresTotais": 0,
-          "caracteresPor1000px": 0
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -5735,7 +5801,7 @@
     },
     "dvo": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:18:06.197Z",
+      "dataHora": "2026-09-10T17:50:09.584Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 900,
@@ -5897,7 +5963,10 @@
         "caixaAlta": {
           "elementos": 0,
           "caracteresTotais": 0,
-          "caracteresPor1000px": 0
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -5974,7 +6043,7 @@
   "variantesDaLP": {
     "A-lp-atual@1440": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:18:17.700Z",
+      "dataHora": "2026-09-10T17:50:21.166Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 8374,
@@ -5982,7 +6051,7 @@
         "carregadas": 0
       },
       "data": {
-        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/pesquisa-tipografia-o-eixo-que-classifica-15-15/wireframes/lp-final.html",
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html",
         "altura": 8374,
         "fontes": {
           "status": "loaded",
@@ -6216,9 +6285,12 @@
           "porRecorte": []
         },
         "caixaAlta": {
-          "elementos": 55,
-          "caracteresTotais": 854,
-          "caracteresPor1000px": 101.98
+          "elementos": 96,
+          "caracteresTotais": 1513,
+          "caracteresPor1000px": 180.68,
+          "semNeutralizar": 55,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -6302,11 +6374,11 @@
         }
       ],
       "variante": "A-lp-atual",
-      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/pesquisa-tipografia-o-eixo-que-classifica-15-15/wireframes/lp-final.html"
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html"
     },
     "B-so-escala@1440": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:18:29.888Z",
+      "dataHora": "2026-09-10T17:50:33.521Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 10604,
@@ -6314,7 +6386,7 @@
         "carregadas": 0
       },
       "data": {
-        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/pesquisa-tipografia-o-eixo-que-classifica-15-15/wireframes/lp-final.html",
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html",
         "altura": 10604,
         "fontes": {
           "status": "loaded",
@@ -6548,9 +6620,12 @@
           "porRecorte": []
         },
         "caixaAlta": {
-          "elementos": 13,
-          "caracteresTotais": 226,
-          "caracteresPor1000px": 21.31
+          "elementos": 23,
+          "caracteresTotais": 467,
+          "caracteresPor1000px": 44.04,
+          "semNeutralizar": 13,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -6634,11 +6709,11 @@
         }
       ],
       "variante": "B-so-escala",
-      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/pesquisa-tipografia-o-eixo-que-classifica-15-15/wireframes/lp-final.html"
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html"
     },
     "C-escala-evento-curto@1440": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:18:41.972Z",
+      "dataHora": "2026-09-10T17:50:45.826Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 10169,
@@ -6646,7 +6721,7 @@
         "carregadas": 0
       },
       "data": {
-        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/pesquisa-tipografia-o-eixo-que-classifica-15-15/wireframes/lp-final.html",
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html",
         "altura": 10169,
         "fontes": {
           "status": "loaded",
@@ -6880,9 +6955,12 @@
           "porRecorte": []
         },
         "caixaAlta": {
-          "elementos": 13,
-          "caracteresTotais": 226,
-          "caracteresPor1000px": 22.22
+          "elementos": 23,
+          "caracteresTotais": 467,
+          "caracteresPor1000px": 45.92,
+          "semNeutralizar": 13,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -6966,11 +7044,11 @@
         }
       ],
       "variante": "C-escala-evento-curto",
-      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/pesquisa-tipografia-o-eixo-que-classifica-15-15/wireframes/lp-final.html"
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html"
     },
     "A-lp-atual@390": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:18:53.587Z",
+      "dataHora": "2026-09-10T17:50:57.551Z",
       "viewport": "390x844x2",
       "rolagem": {
         "altura": 11078,
@@ -6978,7 +7056,7 @@
         "carregadas": 0
       },
       "data": {
-        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/pesquisa-tipografia-o-eixo-que-classifica-15-15/wireframes/lp-final.html",
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html",
         "altura": 11078,
         "fontes": {
           "status": "loaded",
@@ -7212,9 +7290,12 @@
           "porRecorte": []
         },
         "caixaAlta": {
-          "elementos": 48,
-          "caracteresTotais": 760,
-          "caracteresPor1000px": 68.6
+          "elementos": 89,
+          "caracteresTotais": 1419,
+          "caracteresPor1000px": 128.09,
+          "semNeutralizar": 48,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -7298,11 +7379,11 @@
         }
       ],
       "variante": "A-lp-atual",
-      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/pesquisa-tipografia-o-eixo-que-classifica-15-15/wireframes/lp-final.html"
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html"
     },
     "B-so-escala@390": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:19:05.918Z",
+      "dataHora": "2026-09-10T17:51:09.794Z",
       "viewport": "390x844x2",
       "rolagem": {
         "altura": 12444,
@@ -7310,7 +7391,7 @@
         "carregadas": 0
       },
       "data": {
-        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/pesquisa-tipografia-o-eixo-que-classifica-15-15/wireframes/lp-final.html",
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html",
         "altura": 12444,
         "fontes": {
           "status": "loaded",
@@ -7544,9 +7625,12 @@
           "porRecorte": []
         },
         "caixaAlta": {
-          "elementos": 13,
-          "caracteresTotais": 226,
-          "caracteresPor1000px": 18.16
+          "elementos": 23,
+          "caracteresTotais": 467,
+          "caracteresPor1000px": 37.53,
+          "semNeutralizar": 11,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -7630,11 +7714,11 @@
         }
       ],
       "variante": "B-so-escala",
-      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/pesquisa-tipografia-o-eixo-que-classifica-15-15/wireframes/lp-final.html"
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html"
     },
     "C-escala-evento-curto@390": {
       "status": "sucesso",
-      "dataHora": "2026-09-08T02:19:18.368Z",
+      "dataHora": "2026-09-10T17:51:22.094Z",
       "viewport": "390x844x2",
       "rolagem": {
         "altura": 12399,
@@ -7642,7 +7726,7 @@
         "carregadas": 0
       },
       "data": {
-        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/pesquisa-tipografia-o-eixo-que-classifica-15-15/wireframes/lp-final.html",
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html",
         "altura": 12399,
         "fontes": {
           "status": "loaded",
@@ -7876,9 +7960,12 @@
           "porRecorte": []
         },
         "caixaAlta": {
-          "elementos": 13,
-          "caracteresTotais": 226,
-          "caracteresPor1000px": 18.23
+          "elementos": 23,
+          "caracteresTotais": 467,
+          "caracteresPor1000px": 37.66,
+          "semNeutralizar": 13,
+          "passeNeutralizado": true,
+          "amostras": 6
         },
         "familiasUsadas": [
           {
@@ -7962,7 +8049,7 @@
         }
       ],
       "variante": "C-escala-evento-curto",
-      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/pesquisa-tipografia-o-eixo-que-classifica-15-15/wireframes/lp-final.html"
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html"
     }
   }
 }

--- a/docs/design/tipografia/medir.mjs
+++ b/docs/design/tipografia/medir.mjs
@@ -58,6 +58,37 @@ const AMOSTRAS = Number(arg('--amostras', 4));
 const INTERVALO = Number(arg('--intervalo', 1500));
 const SAIDA = resolve(arg('--saida', join(AQUI, 'medicoes.json')));
 
+// Neutraliza o revelador da própria LP para contar caixa alta (issue #46).
+//
+// Por que existe: a LP aplica `.will-reveal { opacity: 0 }` por JS a todo
+// `[data-reveal]` e só solta `.is-revealed` quando o `IntersectionObserver`
+// dispara. A guarda C1 rejeita, corretamente, o que está a `opacity: 0` — então
+// o que a sonda conta depende de o revelador ter disparado.
+//
+// A varredura de 700px com 90ms de pausa NÃO resolve isso, e isto foi medido,
+// não suposto: com `SONDA_DIAG=1`, dos **25** blocos `[data-reveal]` a passada
+// revela **6**. Os outros 19 ficam em `opacity: 0` em todas as amostras, e o
+// campo `caixaAlta` mudava de 46 para 55 entre rodadas conforme quais blocos a
+// corrida pegava. Unir as amostras — que este commit também faz — estabiliza a
+// origem do número mas não o corrige: o teto continua sendo o que a passada
+// revelou. Medir o estado assentado é o que "caixa alta na página inteira"
+// significa.
+//
+// Entra num PASSE PRÓPRIO, no fim, e só a caixa alta dele é aproveitada — nenhum
+// campo geométrico. O escopo é essencial e foi decidido por medição:
+//
+// - `transform: none !important` junto foi tentado e descartado: derrubou
+//   `A-lp-atual@390` de 48 para 22 nós. A guarda C1 não olha transform, então
+//   ele não era necessário para nada.
+// - Só com `opacity`, aplicado desde o início, a altura de `A-lp-atual@1440`
+//   passou de **8.374px para 8.350px** — reprodutível nos dois modos. Eu não
+//   expliquei o mecanismo, e altura é número publicado (o custo de +26,6% sai
+//   dela). Então a neutralização não pode valer para os passes que medem
+//   geometria. Só para contar caixa alta.
+const CSS_REVELADOR_OFF = `
+  [data-reveal], .will-reveal { opacity: 1 !important; }
+`;
+
 // A escala proposta, como folha injetada. Esta é a fonte da verdade do CSS;
 // a cópia no PESQUISA-TIPOGRAFIA.md §8 tem que bater com ela.
 const CSS_ESCALA = `
@@ -169,7 +200,7 @@ async function abrirChrome() {
 // numero decide se a margem do classificador e de 26px ou de 1px, medir uma vez
 // so nao serve. `vistoEmAmostras` registra em quantas cada degrau apareceu, para
 // a instabilidade ficar no dado em vez de virar sorte.
-function unirAmostras(amostras) {
+function unirAmostras(amostras, amostraCaps) {
   const ultima = amostras[amostras.length - 1];
   const d = { ...ultima };
   const porPx = new Map();
@@ -202,10 +233,44 @@ function unirAmostras(amostras) {
   d.pontoCego = maior ? maior.px > maiorH : false;
   d.diferencaPx = maior ? maior.px - maiorH : 0;
 
+  // C6 — caixa alta se une pelo CONJUNTO DE NÓS, não pela contagem.
+  // Contagem não se une: máximo entre amostras herda o ruído da amostra mais
+  // sortuda, e deixar `caixaAlta` vir de carona no `{ ...ultima }` fazia o campo
+  // depender de a varredura ter revelado cada bloco `[data-reveal]` antes da
+  // amostra pós-rolagem — corrida entre instrumento e página, que é o que fazia
+  // o mesmo arquivo medir 46, 55, 67 ou 70 (issue #46). Aqui vale o princípio já
+  // usado nos títulos: une, e registra em quantas amostras cada nó apareceu,
+  // para a instabilidade ficar no dado em vez de virar sorte.
+  const capsPorCaminho = new Map();
+  for (const a of (amostraCaps ? [...amostras, amostraCaps] : amostras)) {
+    for (const n of (a.caixaAlta?.nos || [])) {
+      if (!capsPorCaminho.has(n.caminho)) capsPorCaminho.set(n.caminho, n);
+    }
+  }
+  const capsChars = [...capsPorCaminho.values()].reduce((s, n) => s + n.caracteres, 0);
+  // Quanto o revelador escondia, no próprio dado: o maior que os passes NÃO
+  // neutralizados conseguiram ver. É o número que este projeto publicou antes
+  // (55 a 1440) e serve para auditar a diferença sem reler o histórico.
+  const capsSemNeutralizar = amostras.reduce(
+    (m, a) => Math.max(m, (a.caixaAlta?.nos || []).length), 0);
+  d.caixaAlta = {
+    elementos: capsPorCaminho.size,
+    caracteresTotais: capsChars,
+    caracteresPor1000px: d.altura > 0 ? Math.round(capsChars / d.altura * 1000 * 100) / 100 : 0,
+    semNeutralizar: capsSemNeutralizar,
+    passeNeutralizado: !!amostraCaps,
+    amostras: amostras.length + (amostraCaps ? 1 : 0)
+  };
+
   d.descartes = {
     titulos: (ultima.descartes?.titulos || []).filter(x => !porPx.has(x.px)),
     porRecorte: ultima.descartes?.porRecorte || []
   };
+  // `_diag` é instrumento de diagnóstico, não medição: `isRevealed` varia entre
+  // rodadas porque a corrida do revelador continua existindo — ela só deixou de
+  // afetar o resultado. Fica fora do JSON para o arquivo ser determinístico;
+  // veja com `SONDA_DIAG=1`.
+  delete d._diag;
   d._amostras = amostras.length;
   d._instavel = d.titulosDetalhes.some(t => t.vistoEmAmostras !== `${amostras.length}/${amostras.length}`);
   return d;
@@ -276,7 +341,31 @@ async function medirPagina(cdp, url, vp, { css, js } = {}) {
     const rolagem = await aval(`(${ROLAR})()`, true);
     amostras.push(await aval(`(${sonda.toString()})()`));
 
-    const dados = unirAmostras(amostras);
+    // TERCEIRO PASSE, só para caixa alta (issue #46).
+    // A varredura acima revela 6 dos 25 blocos `[data-reveal]` da LP — medido com
+    // `SONDA_DIAG=1`, não suposto. Os outros 19 ficam em `opacity: 0`, a guarda C1
+    // os rejeita corretamente, e o número de caixa alta virava função de quais
+    // blocos a corrida pegou. Aqui o revelador é neutralizado e a página é
+    // amostrada uma última vez; desta amostra aproveita-se **apenas** a caixa
+    // alta, porque a folha injetada altera altura em 24px por motivo que eu não
+    // determinei. Geometria continua vindo dos passes anteriores, intactos.
+    let amostraCaps = null;
+    try {
+      await aval(`(() => { const st = document.createElement('style');
+        st.id = 'revelador-off'; st.textContent = ${JSON.stringify(CSS_REVELADOR_OFF)};
+        document.head.appendChild(st); return true; })()`);
+      await dormir(300);
+      amostraCaps = await aval(`(${sonda.toString()})()`);
+    } catch {}
+
+    if (process.env.SONDA_DIAG) {
+      for (const [i, a] of amostras.entries()) {
+        const g = a._diag || {};
+        console.error(`    DIAG a${i}: caps=${a.caixaAlta?.nos?.length} reduce=${g.reduce}`
+          + ` dataReveal=${g.dataReveal} will=${g.willReveal} revealed=${g.isRevealed}`);
+      }
+    }
+    const dados = unirAmostras(amostras, amostraCaps);
     return { status: 'sucesso', dataHora: new Date().toISOString(),
              viewport: `${vp.w}x${vp.h}x${vp.dpr}`, rolagem, data: dados,
              amostras: amostras.map((a, i) => ({

--- a/docs/design/tipografia/medir.mjs
+++ b/docs/design/tipografia/medir.mjs
@@ -403,7 +403,12 @@ const saida = {
     sonda: 'docs/design/tipografia/sonda-tipografia.mjs',
     alvos: 'docs/design/tipografia/alvos.json',
     nota: 'Nao ha arquivo de prototipo. O "depois" da escala e medido por injecao ' +
-          'de CSS sobre a wireframes/lp-final.html real. Ver provenance.md P-015.'
+          'de CSS sobre a wireframes/lp-final.html real. Ver provenance.md P-015.',
+    notaCaixaAlta: 'caixaAlta.semNeutralizar NAO e numero citavel: e a contagem ' +
+          'sem neutralizar o revelador, ou seja, a propria grandeza nao ' +
+          'deterministica que a issue #46 conserta, e varia entre rodadas. ' +
+          'Existe so para dimensionar quanto o revelador escondia. O numero ' +
+          'valido e caixaAlta.elementos, medido no passe neutralizado.'
   },
   referencias: {},
   variantesDaLP: {}

--- a/docs/design/tipografia/sonda-tipografia.mjs
+++ b/docs/design/tipografia/sonda-tipografia.mjs
@@ -109,6 +109,22 @@ export const sonda = () => {
 
   const visivel = (el, cs) => porQueInvisivel(el, cs) === null;
 
+  // Identidade estável de um nó entre amostras da mesma página. Precisa ser
+  // estável porque a união de caixa alta (C6) acontece no driver, comparando
+  // amostra a amostra: o revelador da própria página muda `opacity` e classe,
+  // nunca a estrutura, então caminho por posição serve e não colide.
+  const caminhoDom = (el) => {
+    const partes = [];
+    for (let n = el; n && n.nodeType === 1 && n !== document.body; n = n.parentElement) {
+      let i = 1;
+      for (let s = n.previousElementSibling; s; s = s.previousElementSibling) {
+        if (s.tagName === n.tagName) i++;
+      }
+      partes.unshift(n.tagName.toLowerCase() + (i > 1 ? ':' + i : ''));
+    }
+    return partes.join('>');
+  };
+
   // ==========================================================================
   // C2 — recorte por maquinário, NÃO por posição de rolagem
   // ==========================================================================
@@ -186,7 +202,7 @@ export const sonda = () => {
     return { razao: null, origem: 'indisponivel' };
   };
 
-  let upperCount = 0, upperChars = 0;
+  const caixaAltaNos = [];
   const fontsInUse = new Map();
 
   // ==========================================================================
@@ -362,7 +378,12 @@ export const sonda = () => {
     const txt = direto.trim();
     if (!txt) continue;
     if (!visivel(el, cs)) continue;
-    upperCount++; upperChars += txt.length;
+    const clsCA = typeof el.className === 'string' ? el.className.trim()
+      : (el.className && el.className.baseVal ? el.className.baseVal.trim() : (el.getAttribute('class') || ''));
+    caixaAltaNos.push({
+      caminho: caminhoDom(el), tag: el.tagName.toLowerCase(),
+      className: clsCA, caracteres: txt.length
+    });
   }
 
   const altura = Math.max(document.documentElement.scrollHeight, document.body ? document.body.scrollHeight : 0);
@@ -462,7 +483,21 @@ export const sonda = () => {
     },
     descartes: { titulos: titDescartados, porRecorte: descartadosPorRecorte },
 
-    caixaAlta: { elementos: upperCount, caracteresTotais: upperChars, caracteresPor1000px: p1000(upperChars) },
+    _diag: {
+      reduce: window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+      dataReveal: document.querySelectorAll('[data-reveal]').length,
+      willReveal: document.querySelectorAll('.will-reveal').length,
+      isRevealed: document.querySelectorAll('.is-revealed').length
+    },
+
+    // `nos` existe para o driver unir entre amostras; ele não vai para o JSON
+    // final. Os agregados aqui são desta amostra só — a união os substitui.
+    caixaAlta: {
+      elementos: caixaAltaNos.length,
+      caracteresTotais: caixaAltaNos.reduce((s, n) => s + n.caracteres, 0),
+      caracteresPor1000px: p1000(caixaAltaNos.reduce((s, n) => s + n.caracteres, 0)),
+      nos: caixaAltaNos
+    },
     familiasUsadas: [...fontsInUse.entries()].sort((a,b)=>b[1]-a[1]).map(([familia, contagem]) => ({familia, contagem})),
 
     maiorTextoRenderizado,


### PR DESCRIPTION
Fecha a #46. O campo `caixaAlta` era não determinístico — quatro valores medidos para a mesma página (46, 55, 67, 70) — e sustentava uma manchete do `PESQUISA-TIPOGRAFIA.md`.

## A causa, medida e não suposta

`unirAmostras` unia título, *workhorse* e maior texto entre as amostras, mas `caixaAlta` entrava de carona no `{ ...ultima }`: vinha só da amostra pós-rolagem. E aí encontrava o maquinário da própria LP — `.will-reveal { opacity: 0 }` em todo `[data-reveal]`, solto pelo `IntersectionObserver` — que a guarda C1 rejeita, corretamente.

Instrumentei o driver (`SONDA_DIAG=1`) para ver o estado do revelador por amostra. O resultado corrige o que eu mesmo escrevi na issue:

```
DIAG a0: caps=46 reduce=false dataReveal=25 will=25 revealed=1
DIAG a4: caps=55 reduce=false dataReveal=25 will=25 revealed=5
```

**A varredura de 700px com 90ms de pausa revela 6 dos 25 blocos.** Os outros 19 ficam em `opacity: 0` em todas as amostras. Então **unir as amostras não basta** — eu havia afirmado na issue que qualquer uma das duas correções resolveria, e isso é falso: a união estabiliza a *origem* do número, mas o teto continua sendo o que a passada revelou.

## O que este PR faz

**1. Une `caixaAlta` pelo conjunto de nós**, não pela contagem. Contagem não se une — máximo entre amostras herda o ruído da amostra mais sortuda. A sonda passa a devolver identidade de nó (caminho no DOM) e o driver une por ela, mesmo princípio que `titulosDetalhes` já usava com `px` e `vistoEmAmostras`.

**2. Acrescenta um passe final com o revelador neutralizado**, e só a caixa alta dele é aproveitada.

O escopo desse passe foi decidido por medição, em duas tentativas descartadas:

| tentativa | efeito medido | veredito |
|---|---|---|
| `opacity: 1` + `transform: none` desde o início | `A-lp-atual@390` caiu de 48 para **22** nós | descartada — a guarda C1 não olha transform, então ele era inútil, e zerar transform mexe em layout |
| só `opacity: 1`, desde o início | altura de `A-lp-atual@1440` foi de 8.374 para **8.350px** | descartada — não determinei o mecanismo, e altura é número publicado |

Daí o passe isolado no fim: **nenhum campo geométrico sai dele.** Confirmado — as alturas voltaram idênticas às da `develop`.

## Os números, corrigidos

A base publicada subcontava pela metade:

| | publicado | neste PR |
|---|---|---|
| `A-lp-atual@1440` | 55 elementos · 854 car. | **96 · 1.513** |
| `A-lp-atual@390` | 48 · 760 | **89 · 1.419** |
| `B`/`C` (ambos viewports) | 13 · 226 | **23 · 467** |
| queda a 1440 | −76,4% (elementos) | **−76,0%** elementos · **−69,1%** caracteres |
| queda a 390 | −70,3% (era caractere rotulado como elemento) | **−74,2%** elementos · **−67,1%** caracteres |

A conclusão sobrevive — a direção e a ordem de grandeza eram robustas —, mas agora o número reproduz.

**Uma referência também mudou:** `lxlcreative` foi de 26 para **30** nós. A união entre amostras achou 4 nós que a versão anterior perdia, o que mostra que ela faz trabalho útil mesmo onde não há revelador. As outras 17 não mudaram.

## Os três itens de precisão da issue

- **Unidade misturada** no item 4 das DECISÕES: *"−76,4% a 1440px e −70,3% a 390px"* misturava queda de elementos com queda de caracteres. Agora as duas unidades aparecem separadas nos dois viewports.
- **Reconciliação de razão:** o `REFERENCE-BOARD-v3` publica **3,29×** e este documento **3,54×** para a mesma página. Os dois estão certos sob a régua de cada um — 14px contra 13px de *workhorse* — e o texto agora diz isso.
- **Limites declarados** no §9.1: a caixa alta exige o revelador neutralizado, com o comando de reprodução escrito ao lado.

## Achado novo, declarado e não resolvido

**A altura de `A-lp-atual@1440` alterna entre 8.350px e 8.374px entre rodadas**, independente das mudanças deste PR. Descobri ao verificar a correção. É um segundo defeito de determinismo, num campo que sustenta o `+2.230px / +26,6%` publicado no §8.

Está declarado no §9.1 com a incerteza de **±24px** na base, sem recalcular e sem maquiar. Fora do escopo desta issue — decidir se vira issue própria ou entra na #45, que já vai remedir alturas nos viewports novos.

## Uma armadilha de instrumento que ficou documentada

`--so-local` **sobrescreve** o `medicoes.json` inteiro com apenas as 6 variantes locais, apagando as 18 referências. O primeiro critério de aceite que eu escrevi mandava rodar `--so-local` duas vezes para provar determinismo — e zerou o arquivo. A verificação passou a usar `--saida` para arquivo temporário, e a rodada oficial `--headed` é sempre a última.

## Verificação

**Determinismo (o aceite da issue):** duas rodadas consecutivas de `--so-local --headed --saida <temp>` devolvem os mesmos `elementos` e `caracteresTotais` nas seis variantes. Antes, o mesmo campo dava 46, 55, 67 ou 70.

**Regressão:** comparei todos os campos de classificação — maior título, razão, *workhorse*, altura, maior texto renderizado — contra a `develop`, nas 6 variantes e nas 18 referências:

- **6 de 6 variantes idênticas.** 144px, 11,08×, 48px, 3,69×, alturas: nada se moveu.
- **15 de 18 referências idênticas.** As outras três divergem **só na altura da página** — `paulkalkbrenner` 10.711→10.709, `obspogon` 2.986→3.061, `simonbetton` 9.277→9.298. São sites ao vivo que mudaram entre as rodadas; título, razão e *workhorse* batem nas três.

**Higiene:** `caixaAlta.nos` e `_diag` são instrumento e não vão para o JSON. `_meta.notaCaixaAlta` declara que `caixaAlta.semNeutralizar` **não é número citável** — é a contagem sem neutralizar, varia entre rodadas (11 ou 13 em `B-so-escala@390`) e existe só para dimensionar quanto o revelador escondia. Sem essa nota ele viraria o próximo "55".

**Definição de pronto:** os checks de CI decidem os itens 1 e 3. Os itens 2, 4 e 5 não se aplicam — este PR não toca `wireframes/lp-final.html`, não acrescenta texto de interface e não acrescenta movimento. Nenhuma afirmação nova sem origem rastreável: cada número do documento sai do `medicoes.json` deste commit, e os dois limites do §9.1 trazem o comando de reprodução.

## Sequência

A #45 mexe no mesmo `medir.mjs` — ela generaliza o viewport de dois para cinco. Este PR entra primeiro para as duas não conflitarem.
