### PR TITLE
feat(pesquisa): o degrau movel da escala, contra o corte de cada largura (#45)

### DIFF
--- a/docs/design/PESQUISA-TIPOGRAFIA.md
+++ b/docs/design/PESQUISA-TIPOGRAFIA.md
@@ -280,6 +280,103 @@ A variante C acrescentou a essa folha a execução do script `JS_EVENTO_CURTO`, 
 
 ---
 
+
+### 8.4 O degrau móvel — cinco larguras, e o corte de cada uma (issue #45)
+
+A §8.1 mediu dois viewports e concluiu que a escala ficava do lado rejeitado a
+390px. Aquela conclusão usava o corte de **desktop**. A #45 mediu as 18
+referências em 320, 390 e 768px — 54 medições, em
+`docs/design/tipografia/medicoes-movel.json` — e o corte de desktop **não
+sobrevive ao móvel**.
+
+**A 390px, quatro das cinco peças aprovadas ficam abaixo de 89px:** `aelixa`
+80px, `lxlcreative` 64px, `paulkalkbrenner` 60px e `illoca` 58px. Só
+`white-desert`, com 200px, cruza. Perseguir 89px a 390px deixaria a LP mais
+extrema que quatro quintos da própria referência do cliente.
+
+#### O corte de cada largura, pelo método da §3.4
+
+Pior aprovado contra melhor rejeitado, corte no ponto médio:
+
+| largura | corte de título | corte de razão |
+|---|---|---|
+| 320 | **não existe** — a variável inverte: `illoca` (aprovada) 47px fica **abaixo** de `lowmess` (rejeitada) 48px | **3,73×** |
+| 390 | **54px** (`illoca` 58 · `lowmess` 50) | **3,66×** (`paulkalkbrenner` 3,75 · `lowmess` 3,57) |
+| 768 | **70,5px** (`lxlcreative` 80 · `lowmess` 61) | **4,39×** (`lxlcreative` 4,71 · `lowmess` 4,07) |
+| 1024 e 1440 | 89px | 5,57× |
+
+**A 320px, uma das duas variáveis classificadoras falha.** É a primeira vez neste
+projeto que isso acontece. Ali só a razão separa, e por 0,08.
+
+#### A escala revisada, e o resultado medido
+
+O `PLANO-DEGRAU-MOVEL.md` propôs alterar apenas o primeiro degrau, mantendo o
+segundo, o teto de 144px e as famílias:
+
+```css
+font-size:     clamp(3.0625rem, max(10vw, min(14vw, 3.375rem)), 9rem);
+line-height:   clamp(.9em, 3.375rem, 1em);
+overflow-wrap: anywhere;
+```
+
+A ponte `min(14vw, 3.375rem)` só atua **abaixo de 540px**, onde `10vw` ainda não
+alcançou 54px — de 540 para cima a curva é exatamente a anterior. A entrelinha
+abre para um corpo no móvel e reencontra `0.9em` em 600px.
+
+Medido em `--headed`, 33/33, contra o corte de cada largura:
+
+| largura | maior título | razão | corte de título | corte de razão |
+|---|---|---|---|---|
+| 320 | **49px** | **3,77×** | não existe | 3,73× · **cruza por 0,04** |
+| 390 | **54px** | **4,15×** | 54px · **cruza com margem zero** | 3,66× |
+| 768 | **77px** | **5,92×** | 70,5px | 4,39× |
+| 1024 | **102px** | **7,85×** | 89px | 5,57× |
+| 1440 | **144px** | **11,08×** | 89px | 5,57× |
+
+As cinco larguras cruzam o corte da sua própria largura. O *workhorse* medido
+continua **13px** nas quinze linhas, e a variante `A-lp-atual` não se move em
+largura nenhuma — ela não recebe CSS injetado.
+
+#### O que este resultado não autoriza concluir
+
+- **A classificação no móvel é frágil, e são duas fragilidades distintas.** A
+  primeira é a **separação da amostra**: a distância entre o pior aprovado e o
+  melhor rejeitado em maior título cai de **26px** a 1440px (102 contra 76) para
+  **8px** a 390px (58 contra 50), e a 320px fica **negativa** (47 contra 48). A
+  segunda é a **folga da LP até o corte**: 0,04 em razão a 320px e **zero** em
+  título a 390px. A amostra aprovada tem **N=5**, e as dez rejeitadas vêm de um
+  único agregador (§9.2) — limite que pesa mais justamente onde a separação
+  encolhe.
+- **A 390px o título cai exatamente sobre o corte.** O corte é o ponto médio
+  entre 58px (pior aprovada) e 50px (melhor rejeitada): a LP fica na fronteira,
+  não dentro da faixa aprovada. Foi o alvo escolhido no gate, e é conformidade,
+  não folga.
+- **Nada foi conferido em navegador.** As previsões de quebra de linha do
+  `PLANO-DEGRAU-MOVEL.md` — seis linhas a 320px, cinco a 390px — são previsão de
+  composição, não observação. O `h1` está dentro de `.hero-mask` com
+  `overflow: hidden`, e **ausência de rolagem horizontal não prova que o texto
+  não foi cortado**. A crítica visual é da #21 e do Gate C.
+
+#### Um efeito colateral não previsto, e medido
+
+`overflow-wrap: anywhere` altera o cálculo de tamanho intrínseco, e com ele a
+altura da página. Comparando a mesma variante antes e depois, a 1440px:
+
+| variante @1440 | escala anterior | escala com o degrau móvel |
+|---|---|---|
+| `B-so-escala` | 10.604px | **10.863px** |
+| `C-escala-evento-curto` | 10.169px | **10.299px** |
+
+São **+259px** e **+130px** que não vêm do tamanho do tipo — o título a 1440px
+continua 144px e a razão 11,08×. Vêm da propriedade de quebra.
+
+O custo de altura da escala, discutido na §6, sobe de **+2.230px (+26,6%)** para
+**+2.513px (+30,1%)** a 1440px — de 8.350px para 10.863px. Continua remetido à
+**#7**, agora com o alvo de ≤5.500px do `PROBLEMA-v1` mais distante: o corte de
+11 para 8 seções passa a ter que pagar **5.363px**.
+
+---
+
 ## 9. Limites declarados e o que continua não medido
 
 ### 9.1 Limites operacionais do instrumento
@@ -288,6 +385,8 @@ A variante C acrescentou a essa folha a execução do script `JS_EVENTO_CURTO`, 
 - **Caixa alta exige o revelador neutralizado:** A varredura de 700px com pausa de 90ms revela 6 dos 25 blocos `[data-reveal]`; sem neutralizar, a contagem depende de qual bloco a corrida alcançou. O passe neutralizado mede o estado assentado da página, correspondente a “caixa alta na página inteira”. A origem é reproduzível com `SONDA_DIAG=1 node docs/design/tipografia/medir.mjs --so-local --headed`, que imprime `dataReveal` e `revealed` por amostra.
 - **Altura não determinística da Variante A em desktop:** Duas execuções do comando gravado em `_meta.comando` devolveram **8.350px** e **8.374px** para `A-lp-atual@1440`. A oscilação não está resolvida nesta issue; por isso, o custo de altura publicado no §8 (**+2.230px, +26,6%**) carrega incerteza de **±24px** na base.
 - **O wordmark de rodapé não substitui a hierarquia:** O `<div class="footer-wordmark">` de 232px da LP localiza-se a 95,9% de rolagem. O `aelixa.webflow.io` (aprovado) possui idêntica estrutura: um elemento de **240px a 97,8%** de profundidade. A presença de uma palavra gigante no encerramento da página aparece nos dois lados do espectro e **não separa aprovação de rejeição**. O que separa os grupos é a escala que governa os títulos de conteúdo ativo (102–320px vs 20–76px).
+
+- **A altura da variante `A-lp-atual` oscila cerca de 25px entre rodadas, e a #45 não fechou a causa.** O desvio aparece em **uma largura por rodada**, não sempre na mesma: `A-lp-atual@1440` mediu 8.374px e 8.350px em rodadas diferentes, e `A-lp-atual@768` mediu 10.934px e 10.959px. Nas demais quatorze linhas as três rodadas conferidas batem exatamente. Duas hipóteses foram **refutadas com dado**, não descartadas por opinião: (1) *o revelador* — com `SONDA_DIAG=1` a 320px, `isRevealed` sobe de 0 para 5 entre as amostras e a altura permanece 11.644px nas cinco, logo o `transform` dos blocos `[data-reveal]` não move a altura; (2) *imagem preguiçosa* — a LP não tem elemento `<img>` algum, `rolagem.imgs` é **0**. Consequência a declarar em qualquer citação: toda altura publicada carrega incerteza de **±25px**, e diferenças menores que isso entre duas medições não são sinal.
 
 ### 9.2 O que continua estritamente não medido
 
@@ -310,8 +409,8 @@ A variante C acrescentou a essa folha a execução do script `JS_EVENTO_CURTO`, 
 5. Extinção definitiva de arquivos de protótipo de escala (`escala-proposta-*`), adotando-se a injeção em tempo de medição como metodologia de aferição.
 
 **QUESTÕES ABERTAS:**
-1. **O degrau móvel da escala segue não resolvido:** A 390px, a escala proposta atinge 48px e razão 3,69×, permanecendo do lado rejeitado pelo classificador. Projetar uma adaptação responsiva viável sem overflow horizontal é questão aberta para o Gate C;
-2. **Dilatação da página versus tempo até a prova técnica:** O aumento de 26,6% na altura total (para 11,8 telas) tensiona a métrica de ≤ 1,5 tela para exibição de evidências técnicas do `PROBLEMA-v1.md`;
+1. **O degrau móvel foi resolvido contra o corte de cada largura, não contra o de desktop (#45):** a escala revisada mede 49px a 320, 54px a 390 e 77px a 768, cruzando o corte da própria largura nas cinco medidas — §8.4. O que **permanece aberto** é a folga: a 390px o título cai exatamente sobre o corte, com margem zero, e a 320px a variável de título não separa aprovado de rejeitado. Nada foi conferido em navegador, e a máscara do herói tem `overflow: hidden`, então ausência de rolagem horizontal não prova ausência de texto cortado. Crítica visual é da #21 e do Gate C;
+2. **Dilatação da página versus tempo até a prova técnica:** com o degrau móvel aplicado, o aumento a 1440px passa de 26,6% para **30,1%** (+2.513px), porque `overflow-wrap: anywhere` altera o cálculo de tamanho intrínseco — §8.4. A métrica de ≤ 1,5 tela do `PROBLEMA-v1.md` continua sem nunca ter sido medida, e o alvo de ≤5.500px fica a 5.363px de distância;
 3. **Decisão sobre a cópia do herói (Variante C):** A redução para "AUGUSTO MENCHACA" no `h1` e o rebaixamento da frase técnica para subtítulo não afetam as métricas tipográficas. A decisão de hierarquia de mensagem deve ser arbitrada no Gate B/C;
 4. **Governança do workhorse utilitário:** O CSS da escala governa elementos de corpo (`16px`), mas a página computa `13px` em textos secundários de rodapé.
 

--- a/docs/design/tipografia/PLANO-DEGRAU-MOVEL.md
+++ b/docs/design/tipografia/PLANO-DEGRAU-MOVEL.md
@@ -1,0 +1,214 @@
+# Plano do degrau móvel da escala tipográfica — issue #45
+
+Proponho **49px a 320px e 54px a 390px**, com entrelinha de um corpo nessas
+larguras. A curva de tamanho reencontra a escala atual em 540px; a entrelinha
+reencontra a proporção atual em 600px. As duas transições são contínuas.
+O segundo degrau permanece como está. O corpo medido continua sendo 13px.
+
+Este documento é design de execução: contém previsões, não uma nova rodada de
+medição nem aprovação visual. O gate escolheu o corte de cada largura. A
+implementação seguinte substitui somente o bloco de display de `CSS_ESCALA`
+em [medir.mjs](medir.mjs); as demais regras da constante permanecem. A aplicação
+em `wireframes/lp-final.html` depende do Gate D e está fora desta tarefa.
+
+## Evidência e alvo
+
+As observações abaixo vêm de [medicoes-movel.json](medicoes-movel.json), abreviado
+**M**, e [medicoes.json](medicoes.json), abreviado **D**. `M[peça@largura]`
+significa `referencias[peça@largura].data`; `D[B@largura]` significa
+`variantesDaLP["B-so-escala@largura"].data`. Para referências de desktop,
+`D[peça]` significa `referencias[peça].data`, a 1440px.
+Tamanhos são `tamTitulos[0]`, razões são `razaoTituloWorkhorse`, e corpo é
+`workhorse.px`. São os campos corrigidos, nunca `_legado`.
+
+| Largura | Origem do corte de título | Origem do corte de razão |
+| --- | --- | --- |
+| 320 | Não existe: `M[illoca@320]` aprovado, 47px, abaixo de `M[lowmess@320]` rejeitado, 48px. | (`M[paulkalkbrenner@320]` 3,77 + `M[lowmess@320]` 3,69) / 2 = **3,73×**. |
+| 390 | (`M[illoca@390]` 58 + `M[lowmess@390]` 50) / 2 = **54px**. | (`M[paulkalkbrenner@390]` 3,75 + `M[lowmess@390]` 3,57) / 2 = **3,66×**. |
+| 768 | (`M[lxlcreative@768]` 80 + `M[lowmess@768]` 61) / 2 = **70,5px**. | (`M[lxlcreative@768]` 4,71 + `M[lowmess@768]` 4,07) / 2 = **4,39×**. |
+| 1024 e 1440 | (`D[lxlcreative]` 102 + `D[lowmess]` 76) / 2 = **89px**; corte de desktop adotado pelo gate também a 1024. | (`D[lxlcreative]` 6 + `D[thatmlopsguy]` 5,14) / 2 = **5,57×**, com a mesma aplicação do gate. |
+
+`D[B@320]` e `D[B@390]` registram 48px, corpo 13px e razão 3,69×.
+A 320, o mínimo aritmético é `3,73 × 13 = 48,49px`; escolho 49px,
+que também é o tamanho registrado da referência aprovada
+`M[paulkalkbrenner@320]`, com corpo 13px. A 390, o corte de título domina:
+`54 / 13 = 4,153846… > 3,66`. Nenhum corte de título é criado para 320.
+
+## CSS proposto, completo para o bloco de display
+
+```css
+.hero-headline {
+  /* E1–E5: piso móvel, ponte limitada a 54px e curva existente. */
+  font-size: clamp(3.0625rem, max(10vw, min(14vw, 3.375rem)), 9rem) !important;
+  /* E6–E8: um corpo no móvel; retorno contínuo à proporção .9. */
+  line-height: clamp(.9em, 3.375rem, 1em) !important;
+  letter-spacing: -.04em !important; /* E9 */
+  text-transform: none !important; /* E10 */
+  max-width: none !important; /* E11 */
+  overflow-wrap: anywhere !important; /* E12 */
+}
+
+.slab-headline {
+  font-size: clamp(2.25rem, 5vw, 4.5rem) !important; /* E13–E15 */
+  line-height: 1.05 !important; /* E16 */
+  letter-spacing: -.02em !important; /* E17 */
+  text-transform: none !important; /* E18 */
+}
+```
+
+Cada valor tem sua procedência abaixo. Conversões em `rem` usam a raiz de
+16px declarada no HTML nas larguras do aceite; isso é premissa de código,
+não uma nova medição. Valores de projeto e contas derivados estão marcados
+como tal, sem atribuir às referências um CSS que os JSONs não registram.
+
+| ID | Valor escolhido | Evidência ou decisão explícita |
+| --- | --- | --- |
+| E1 | `3.0625rem` = 49px | `M[paulkalkbrenner@320]`: 49px, corpo 13px, razão 3,77×. Adoto seu tamanho **arredondado registrado**, sem inferir o valor fracionário original da referência. |
+| E2 | `10vw` | Preservação do `CSS_ESCALA`; `D[B@768]`, `D[B@1024]`, `D[B@1440]` registram 77, 102 e 144px, compatíveis com 76,8, 102,4 e 144px antes do arredondamento. |
+| E3 | `14vw` | **Escolha estética de interpolação**, sem medição direta: está entre `100 × 54 / 390 = 13,846154…` e `100 × 49 / 320 = 15,3125`, limites calculados que deixam o piso ativo a 320 e alcançam o teto móvel a 390. |
+| E4 | `3.375rem` = 54px, no tamanho | Corte calculado de `M[illoca@390]` 58px e `M[lowmess@390]` 50px. Limita a contribuição da ponte móvel; a curva `10vw` pode ultrapassá-lo. |
+| E5 | `9rem` = 144px | Teto existente e resultado de `D[B@1440]`, 144px. Preservado. |
+| E6 | `.9em`, na entrelinha | Mantém a proporção de `D[B@768]`, `D[B@1024]` e `D[B@1440]`: `titulosDetalhes[0].lineHeightPx` de 69,12, 92,16 e 129,6px. |
+| E7 | `3.375rem` = 54px, na entrelinha | **Escolha estética de transição**, reutilizando o corte de 390; não é entrelinha medida de uma referência. Mantém a altura de linha em 54px enquanto o título cresce de 54 a 60px. |
+| E8 | `1em`, na entrelinha | `M[aelixa@320]` e `M[aelixa@390]`: `titulosDetalhes[0].lineHeightRazao = 1`. A transferência para Instrument Sans é **hipótese estética**, não prova de legibilidade; abre a linha em relação aos 43,2px atuais de `D[B@320]`. |
+| E9 | `-.04em` | `D[B@320]`: `titulosDetalhes[0].letterSpacing = -1.92px` a 48px, portanto `-1,92 / 48 = -0,04`. Preservo o aperto horizontal para não somar largura ao aumento do corpo. |
+| E10 | `text-transform: none` | `D[B@320]` e `D[B@390]`: `titulosDetalhes[0].textTransform = "none"`. Preservado. |
+| E11 | `max-width: none` | **Decisão de continuidade da composição**, já no `CSS_ESCALA`; o JSON não mede essa propriedade. `D[B@320]` registra contenção 1 para o título, mas isso não comprova ausência de recorte de glifos. A coluna continua sendo o limite de largura. |
+| E12 | `overflow-wrap: anywhere` | **Escolha preventiva de composição**, sem precedente medido. Autoriza quebra dentro da palavra só se ela não couber inteira; não força hifenização, não altera a frase e reduz a contribuição mínima de largura ao grid. |
+| E13 | `2.25rem` = 36px | Piso preservado; `D[B@320].titulosDetalhes[1].px = 36`. |
+| E14 | `5vw` | Curva preservada; `D[B@768]` e `D[B@1024]` registram segundo título de 38 e 51px, compatíveis com 38,4 e 51,2px antes do arredondamento. |
+| E15 | `4.5rem` = 72px | Teto preservado; `D[B@1440].titulosDetalhes[1].px = 72`. |
+| E16 | `1.05` | `D[B@320].titulosDetalhes[1].lineHeightPx = "37.8px"` a 36px: `37,8 / 36 = 1,05`. |
+| E17 | `-.02em` | `D[B@320].titulosDetalhes[1].letterSpacing = "-0.72px"` a 36px: `-0,72 / 36 = -0,02`. |
+| E18 | `text-transform: none` | `D[B@320].titulosDetalhes[1].textTransform = "none"`. Preservado. |
+| E19 | `!important`, em todas as declarações | **Decisão técnica de injeção**, seguindo o bloco atual; a folha injetada precisa prevalecer sobre as regras responsivas do produto. Não é dado de preferência. |
+
+## Predição conferível
+
+Seja `W` a largura em CSS px, `H` o tamanho do hero e `L` sua altura de linha:
+
+```text
+H(W) = max(49, min(max(0,10W, min(0,14W, 54)), 144))
+L(W) = max(0,9H, min(54, H))
+S(W) = max(36, min(0,05W, 72))  [segundo degrau]
+R(W) = H(W) / 13
+```
+
+Nas fórmulas, vírgula é decimal; em `max(0,10W, …)`, o primeiro argumento é
+`0,10 × W`. A tabela explicita cada conta para evitar ambiguidade.
+
+| W | Conta do título, em px | H computado | H / 13, sem arredondar H | Saída prevista da sonda: título / razão | L / S, px | Contra o corte da largura |
+| --- | --- | --- | --- | --- | --- | --- |
+| 320 | `max(49; min(max(32; min(44,8; 54)); 144))` | **49** | `49 / 13 = 3,769231…` | **49 / 3,77×** | 49 / 36 | Razão > 3,73; não há corte de título. |
+| 390 | `max(49; min(max(39; min(54,6; 54)); 144))` | **54** | `54 / 13 = 4,153846…` | **54 / 4,15×** | 54 / 36 | Título = 54; razão > 3,66. |
+| 768 | `max(49; min(max(76,8; min(107,52; 54)); 144))` | **76,8** | `76,8 / 13 = 5,907692…` | **77 / 5,92×** | 69,12 / 38,4 | Título > 70,5; razão > 4,39. |
+| 1024 | `max(49; min(max(102,4; min(143,36; 54)); 144))` | **102,4** | `102,4 / 13 = 7,876923…` | **102 / 7,85×** | 92,16 / 51,2 | Título > 89; razão > 5,57. |
+| 1440 | `max(49; min(max(144; min(201,6; 54)); 144))` | **144** | `144 / 13 = 11,076923…` | **144 / 11,08×** | 129,6 / 72 | Título > 89; razão > 5,57. |
+
+A sonda faz `Math.round(fontSize)` antes de calcular e arredondar a razão;
+ver [sonda-tipografia.mjs](sonda-tipografia.mjs), atribuição de `fs` dos títulos
+e retorno de `razaoTituloWorkhorse`. Por isso 76,8px dá 5,907692… na conta
+contínua, mas **77px e 5,92×** no JSON. A coluna da sonda mantém a semântica
+dos dados que originaram os cortes. As duas formas de cálculo passam.
+
+Com raiz de 16px, as junções calculadas são: piso até `49 / 0,14 = 350px`;
+rampa até `54 / 0,14 = 385,714286…px`; patamar até `54 / 0,10 = 540px`;
+depois `10vw`, limitado pelo teto. A linha fica em `1em` até H = 54px,
+em 54px até `54 / 0,9 = 60px` de título, e depois em `.9em`.
+Isso dispensa um breakpoint que faça o título ou sua entrelinha saltar.
+
+## Forma esperada, riscos e verificação pelo próximo agente
+
+**Hipótese de quebra a 320px**, com a frase integral registrada em
+`D[B@320].titulosDetalhes[0]` (59 caracteres, 8 palavras):
+
+```text
+Construo
+produtos
+digitais e
+lidero
+projetos de
+tecnologia.
+```
+
+É uma previsão de composição, sem medição de avanço dos glifos. As divisões
+mais sensíveis são depois de “e” e de “lidero”; a fonte efetivamente carregada
+pode alterar esses agrupamentos. Não inserir `<br>` para fabricar a previsão.
+A 390, espero que “digitais e lidero” caiba junto, resultando em cinco linhas:
+“Construo” / “produtos” / “digitais e lidero” / “projetos de” / “tecnologia.”.
+Se essas hipóteses se confirmarem, os blocos de linha terão `6 × 49 = 294px`
+e `5 × 54 = 270px`, sem margens. Não são alturas observadas.
+
+A leitura estática do HTML dá coluna útil de `320 − 2 × 20 = 280px` e
+`390 − 2 × 20 = 350px`: `.container` usa o piso de `--pad` e `.hero-top`
+tem uma coluna nessa faixa. Esses valores são deduções do código, não
+medições dos JSONs. O risco principal é o **`span` dentro de
+`h1.hero-headline.hero-mask`**, sobretudo “tecnologia.”. O h1 e o hero têm
+máscaras com `overflow: hidden`; ausência de rolagem horizontal sozinha pode
+significar texto cortado. `anywhere` deve ser uma reserva, não a quebra usual
+da frase em português. Abertura de linha não garante, por si só, separação
+óptica de ascendentes e descendentes.
+
+O próximo agente deve conferir estes predicados com a folha injetada:
+
+- Nas cinco larguras da tabela, tamanho e razão correspondem às respectivas
+  colunas de predição e cruzam os cortes; `workhorse.px` continua 13. Usar os
+  valores fracionários de `getComputedStyle` além dos campos arredondados;
+  tolerância de leitura proposta: 0,01px para tamanho e entrelinha. Se o corpo
+  medido mudar, recalcular a razão e investigar a mudança antes de aceitar.
+- Fonte efetiva do hero é Instrument Sans, peso 700; segundo degrau mantém
+  Instrument Sans, peso 600, e as dimensões previstas. Inter e IBM Plex Mono
+  conservam seus papéis. São os valores de `D[B@320].titulosDetalhes` e
+  `workhorseDetalhe`, não autorização para trocar famílias.
+- Em 320 e 390, conferir PT e EN após o carregamento das fontes e o fim da
+  entrada, também com movimento reduzido. Registrar a quebra real por palavra
+  e comparar com a hipótese. Nenhuma palavra da frase PT deve precisar de
+  quebra interna; se precisar, a hipótese de forma falhou e volta para revisão.
+  Não diminuir o tamanho para passar silenciosamente.
+- `document.documentElement.scrollWidth <= clientWidth`; também conferir
+  `scrollWidth <= clientWidth` no h1 e no seu span. Retângulos de texto obtidos
+  por `Range` devem ficar dentro da coluna e da máscara, e a inspeção visual
+  deve mostrar todos os glifos sem recorte ou contato entre linhas. Um
+  `fracaoContidaMin = 1` da caixa do título não substitui essa conferência.
+- Conferir ambos os lados das junções calculadas, além das cinco larguras:
+  tamanho e altura de linha não têm salto; a troca de quantidade de linhas
+  por reflow pode acontecer. Em largura igual ou superior a 768px, tamanho,
+  entrelinha, tracking e segundo degrau devem reproduzir a escala anterior.
+- Esperar crescimento vertical no hero móvel e deslocamento do lede, CTAs e
+  cards. Registrar altura do hero, posição do primeiro CTA e altura da página;
+  `D[B@320].altura = 13484` e `D[B@390].altura = 12444` são as bases anteriores,
+  não orçamentos novos nem alturas previstas. Não prometer CTA na primeira
+  tela. Crescimento que não venha do hero exige investigação, pois o segundo
+  degrau e o restante da escala permanecem iguais.
+
+O bloco não declara cor. Mantém a restrição de `--acid #E6F835` nunca como
+texto sobre `paper`, `stone` ou `white`, e a gramática neutra de
+[PESQUISA-PALETA.md §7](../PESQUISA-PALETA.md#7-o-que-fica-pendente-da-36).
+Com raiz de 16px, os pisos dos degraus são 49 e 36px, ambos acima dos 24px
+estipulados no brief para o limiar de contraste 3:1. Se algum cenário reduzir
+um título abaixo desse tamanho, conferir o par contra 4,5:1 conforme o brief;
+não estender o limiar relaxado ao corpo.
+
+## O que decidi não fazer
+
+- **Piso único de 54px em todo móvel ou 89px a 390.** O primeiro consome largura
+  desnecessária a 320; o segundo contraria o gate. A 390, `M[aelixa@390]` 80px,
+  `M[lxlcreative@390]` 64px, `M[paulkalkbrenner@390]` 60px e `M[illoca@390]`
+  58px são aprovados abaixo de 89px.
+- **Encurtar a frase ou aplicar o evento curto da variante C.** A tarefa é a
+  escala com o conteúdo existente. `D[illoca]` registra 121 caracteres e 22
+  palavras a 111px, e `D[paulkalkbrenner]`, 51 caracteres e 8 palavras a 150px:
+  carga, isoladamente, não autoriza edição de conteúdo.
+- **Alterar tracking, impor largura em `ch`, balanceamento ou quebras manuais.**
+  Abro a entrelinha, preservo o tracking e deixo a coluna determinar a medida.
+  Não há observação que justifique acumular essas mudanças; quebras fixas
+  também amarrariam desnecessariamente as versões PT e EN.
+- **Reduzir o corpo para aumentar a razão, aumentar o segundo degrau ou mudar
+  as famílias e pesos.** A lacuna medida é do hero móvel; pesos 800 e 900
+  continuam proibidos.
+- **Ocultar overflow para aprovar o teste, remover máscaras ou mexer no
+  movimento.** É preciso verificar os glifos dentro das máscaras existentes.
+  A quebra preventiva não equivale a uma aprovação visual.
+- **Rodar o driver, regenerar dados ou alterar o produto e documentos
+  existentes.** Esta entrega cria apenas este plano. Medição, crítica visual,
+  síntese final e eventual aplicação no produto pertencem às próximas etapas.

--- a/docs/design/tipografia/alvos.json
+++ b/docs/design/tipografia/alvos.json
@@ -1,7 +1,13 @@
 {
-  "_nota": "Lista versionada dos alvos da issue #36. Editar aqui, nao no driver.",
+  "_nota": "Lista versionada dos alvos da issue #36. Editar aqui, nao no driver. viewportsDaLP serve as variantes da LP; as referencias continuam medidas so no viewportPadrao.",
   "viewportPadrao": { "w": 1440, "h": 900, "dpr": 1 },
-  "viewportMovel":  { "w": 390,  "h": 844, "dpr": 2 },
+  "viewportsDaLP": [
+    { "w": 320,  "h": 568,  "dpr": 2 },
+    { "w": 390,  "h": 844,  "dpr": 2 },
+    { "w": 768,  "h": 1024, "dpr": 2 },
+    { "w": 1024, "h": 768,  "dpr": 1 },
+    { "w": 1440, "h": 900,  "dpr": 1 }
+  ],
   "referencias": [
     { "id": "aelixa",          "url": "https://aelixa.webflow.io",           "rotulo": "aprovado" },
     { "id": "illoca",          "url": "https://illoca.unseen.co",            "rotulo": "aprovado" },

--- a/docs/design/tipografia/alvos.json
+++ b/docs/design/tipografia/alvos.json
@@ -1,5 +1,5 @@
 {
-  "_nota": "Lista versionada dos alvos da issue #36. Editar aqui, nao no driver. viewportsDaLP serve as variantes da LP; as referencias continuam medidas so no viewportPadrao.",
+  "_nota": "Lista versionada dos alvos da issue #36. Editar aqui, nao no driver. viewportsDaLP serve as variantes da LP; por padrao, as referencias continuam medidas so no viewportPadrao.",
   "viewportPadrao": { "w": 1440, "h": 900, "dpr": 1 },
   "viewportsDaLP": [
     { "w": 320,  "h": 568,  "dpr": 2 },
@@ -7,6 +7,11 @@
     { "w": 768,  "h": 1024, "dpr": 2 },
     { "w": 1024, "h": 768,  "dpr": 1 },
     { "w": 1440, "h": 900,  "dpr": 1 }
+  ],
+  "viewportsMoveisDasReferencias": [
+    { "w": 320, "h": 568, "dpr": 2 },
+    { "w": 390, "h": 844, "dpr": 2 },
+    { "w": 768, "h": 1024, "dpr": 2 }
   ],
   "referencias": [
     { "id": "aelixa",          "url": "https://aelixa.webflow.io",           "rotulo": "aprovado" },

--- a/docs/design/tipografia/medicoes-movel.json
+++ b/docs/design/tipografia/medicoes-movel.json
@@ -1,0 +1,17668 @@
+{
+  "_meta": {
+    "gerado": "2026-09-11T01:19:00.879Z",
+    "comando": "node docs/design/tipografia/medir.mjs --headed --so-referencias --refs-moveis --saida docs/design/tipografia/medicoes-movel.json",
+    "comandoOficial": "node docs/design/tipografia/medir.mjs --headed",
+    "modo": "headed",
+    "rodadaOficial": true,
+    "sonda": "docs/design/tipografia/sonda-tipografia.mjs",
+    "alvos": "docs/design/tipografia/alvos.json",
+    "nota": "Nao ha arquivo de prototipo. O \"depois\" da escala e medido por injecao de CSS sobre a wireframes/lp-final.html real. Ver provenance.md P-015.",
+    "notaCaixaAlta": "caixaAlta.semNeutralizar NAO e numero citavel: e a contagem sem neutralizar o revelador, ou seja, a propria grandeza nao deterministica que a issue #46 conserta, e varia entre rodadas. Existe so para dimensionar quanto o revelador escondia. O numero valido e caixaAlta.elementos, medido no passe neutralizado.",
+    "total": 54,
+    "sucessos": 54,
+    "falhas": []
+  },
+  "referencias": {
+    "aelixa@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:19:14.142Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 20386,
+        "imgs": 81,
+        "carregadas": 56
+      },
+      "data": {
+        "url": "https://aelixa.webflow.io/",
+        "altura": 20386,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 116
+        },
+        "viewportMedido": {
+          "w": 320,
+          "h": 568,
+          "dpr": 2
+        },
+        "telas": 35.9,
+        "telas_base900_legado": 22.7,
+        "metricaV2_hsvS015": 1.2,
+        "corPerceptivel_C005": 1.2,
+        "corForte_C012": 1.2,
+        "cromaMedioPonderado": 0.004,
+        "cromaPicoOklch": 0.153,
+        "fundos": [
+          {
+            "cor": "rgb(253,251,248)",
+            "pct": 58.9,
+            "L": 0.99,
+            "C": 0.005,
+            "H": 78
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 22.4,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(36,36,36)",
+            "pct": 16.6,
+            "L": 0.26,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(241,186,53)",
+            "pct": 1.2,
+            "L": 0.82,
+            "C": 0.153,
+            "H": 85
+          },
+          {
+            "cor": "rgb(51,51,51)",
+            "pct": 0.9,
+            "L": 0.32,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(35,35,35)",
+            "pct": 0.1,
+            "L": 0.26,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 81,
+          "svg": 91,
+          "video": 1,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 8.49,
+        "keyframes": 1,
+        "nomes": [
+          "spin"
+        ],
+        "keyframesPor1000": 0.05,
+        "folhasBloqueadas": 2,
+        "emTransicao": 74,
+        "emTransicaoPor1000": 3.63,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            54
+          ],
+          [
+            "0.35s",
+            20
+          ],
+          [
+            "0.4s",
+            2
+          ]
+        ],
+        "tamTitulos": [
+          80,
+          40,
+          38,
+          36,
+          28,
+          24,
+          20
+        ],
+        "workhorse": {
+          "px": 14,
+          "ocorrencias": 5
+        },
+        "razaoTituloWorkhorse": 5.71,
+        "titulosDetalhes": [
+          {
+            "px": 80,
+            "elementos": 1,
+            "caracteres": 7,
+            "palavras": 1,
+            "textos": [
+              "aelixa."
+            ],
+            "fontFamily": "\"Funnel Display\", sans-serif",
+            "familiaEfetiva": "Funnel Display",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "funnel display",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "80px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-4px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 7,
+            "maiorLarguraCh": 7,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 40,
+            "elementos": 6,
+            "caracteres": 150,
+            "palavras": 30,
+            "textos": [
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "48px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.6px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 22,
+            "maiorLarguraCh": 22,
+            "fracaoContidaMin": 0.59,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 38,
+            "elementos": 9,
+            "caracteres": 144,
+            "palavras": 25,
+            "textos": [
+              "Services",
+              "GET STARTED TODAY",
+              "GET STARTED TODAY",
+              "GET STARTED TODAY",
+              "GET STARTED TODAY",
+              "GET STARTED TODAY"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "45.6px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.57px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 12,
+            "maiorLarguraCh": 15,
+            "fracaoContidaMin": 0.86,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 36,
+            "elementos": 12,
+            "caracteres": 279,
+            "palavras": 39,
+            "textos": [
+              "Your Next Best",
+              "Marketing",
+              "Decision",
+              "Starts Here",
+              "Strategy First.\nAlways.",
+              "Strategist-Led Built on Data"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "43.2px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 11,
+            "maiorLarguraCh": 13,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 28,
+            "elementos": 12,
+            "caracteres": 118,
+            "palavras": 21,
+            "textos": [
+              "SEO Optimization",
+              "Performance Marketing",
+              "Content & Social",
+              "Strategy & Data",
+              "Marketing That Makes Sense",
+              "$799"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "39.2px",
+            "lineHeightRazao": 1.4,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 12,
+            "maiorLarguraCh": 16,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 24,
+            "elementos": 11,
+            "caracteres": 398,
+            "palavras": 65,
+            "textos": [
+              "Aura Luxe — Scale Strategy",
+              "FinEdge — Performance UI/UX",
+              "Apex SaaS — Content & SEO",
+              "Vanguard — Digital Identity",
+              "Driving 150% Organic Growth via SEO",
+              "Redefining Luxury ThroughSocial Strategy"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "33.6px",
+            "lineHeightRazao": 1.4,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.36px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 19,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 20,
+            "elementos": 4,
+            "caracteres": 74,
+            "palavras": 11,
+            "textos": [
+              "Aura Luxe — Scale Strategy",
+              "Market Fluidity",
+              "Integrated Ecosystems",
+              "Data Clarity"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "30px",
+            "lineHeightRazao": 1.5,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 16,
+            "maiorLarguraCh": 16,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "1/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 14,
+          "fontFamily": "Inter, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "19.6px",
+          "lineHeightRazao": 1.4,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 25
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            80,
+            40,
+            38,
+            36,
+            28,
+            24,
+            20
+          ],
+          "workhorse_semFiltro": {
+            "px": 14,
+            "ocorrencias": 5
+          },
+          "razao_semFiltro": 5.71,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 16,
+          "caracteresTotais": 318,
+          "caracteresPor1000px": 15.6,
+          "semNeutralizar": 16,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Inter Tight\", sans-serif",
+            "contagem": 54
+          },
+          {
+            "familia": "Inter, sans-serif",
+            "contagem": 6
+          },
+          {
+            "familia": "\"Funnel Display\", sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 80,
+          "tag": "div",
+          "className": "gsap_split_letter gsap_split_letter1",
+          "caracteres": 1,
+          "palavras": 1,
+          "fontFamily": "\"Funnel Display\", sans-serif",
+          "familiaEfetiva": "Funnel Display",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 93.7
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": true
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            80,
+            40,
+            38,
+            36,
+            28,
+            24
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            80,
+            40,
+            38,
+            36,
+            28,
+            24
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            80,
+            40,
+            38,
+            36,
+            28,
+            24
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            80,
+            40,
+            38,
+            36,
+            28,
+            24
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            80,
+            40,
+            38,
+            36,
+            28,
+            24,
+            20
+          ],
+          "maiorTexto": 80
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://aelixa.webflow.io"
+    },
+    "aelixa@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:19:27.201Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 19463,
+        "imgs": 81,
+        "carregadas": 56
+      },
+      "data": {
+        "url": "https://aelixa.webflow.io/",
+        "altura": 19463,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 116
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 23.1,
+        "telas_base900_legado": 21.6,
+        "metricaV2_hsvS015": 1,
+        "corPerceptivel_C005": 1,
+        "corForte_C012": 1,
+        "cromaMedioPonderado": 0.004,
+        "cromaPicoOklch": 0.153,
+        "fundos": [
+          {
+            "cor": "rgb(253,251,248)",
+            "pct": 58.7,
+            "L": 0.99,
+            "C": 0.005,
+            "H": 78
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 22.3,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(36,36,36)",
+            "pct": 16.7,
+            "L": 0.26,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(51,51,51)",
+            "pct": 1,
+            "L": 0.32,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(241,186,53)",
+            "pct": 1,
+            "L": 0.82,
+            "C": 0.153,
+            "H": 85
+          },
+          {
+            "cor": "rgb(35,35,35)",
+            "pct": 0.1,
+            "L": 0.26,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 81,
+          "svg": 91,
+          "video": 1,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 8.89,
+        "keyframes": 1,
+        "nomes": [
+          "spin"
+        ],
+        "keyframesPor1000": 0.05,
+        "folhasBloqueadas": 2,
+        "emTransicao": 74,
+        "emTransicaoPor1000": 3.8,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            54
+          ],
+          [
+            "0.35s",
+            20
+          ],
+          [
+            "0.4s",
+            2
+          ]
+        ],
+        "tamTitulos": [
+          80,
+          40,
+          38,
+          36,
+          28,
+          24,
+          20
+        ],
+        "workhorse": {
+          "px": 14,
+          "ocorrencias": 5
+        },
+        "razaoTituloWorkhorse": 5.71,
+        "titulosDetalhes": [
+          {
+            "px": 80,
+            "elementos": 1,
+            "caracteres": 7,
+            "palavras": 1,
+            "textos": [
+              "aelixa."
+            ],
+            "fontFamily": "\"Funnel Display\", sans-serif",
+            "familiaEfetiva": "Funnel Display",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "funnel display",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "80px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-4px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 8,
+            "maiorLarguraCh": 8,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 40,
+            "elementos": 6,
+            "caracteres": 150,
+            "palavras": 30,
+            "textos": [
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "48px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.6px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 22,
+            "maiorLarguraCh": 22,
+            "fracaoContidaMin": 0.72,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 38,
+            "elementos": 9,
+            "caracteres": 144,
+            "palavras": 25,
+            "textos": [
+              "Services",
+              "GET STARTED TODAY",
+              "GET STARTED TODAY",
+              "GET STARTED TODAY",
+              "GET STARTED TODAY",
+              "GET STARTED TODAY"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "45.6px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.57px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 15,
+            "maiorLarguraCh": 15,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 36,
+            "elementos": 12,
+            "caracteres": 279,
+            "palavras": 39,
+            "textos": [
+              "Your Next Best",
+              "Marketing",
+              "Decision",
+              "Starts Here",
+              "Strategy First.\nAlways.",
+              "Strategist-Led Built on Data"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "43.2px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 11,
+            "maiorLarguraCh": 17,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 28,
+            "elementos": 12,
+            "caracteres": 118,
+            "palavras": 21,
+            "textos": [
+              "SEO Optimization",
+              "Performance Marketing",
+              "Content & Social",
+              "Strategy & Data",
+              "Marketing That Makes Sense",
+              "$799"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "39.2px",
+            "lineHeightRazao": 1.4,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 12,
+            "maiorLarguraCh": 20,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 24,
+            "elementos": 11,
+            "caracteres": 398,
+            "palavras": 65,
+            "textos": [
+              "Aura Luxe — Scale Strategy",
+              "FinEdge — Performance UI/UX",
+              "Apex SaaS — Content & SEO",
+              "Vanguard — Digital Identity",
+              "Driving 150% Organic Growth via SEO",
+              "Redefining Luxury ThroughSocial Strategy"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "33.6px",
+            "lineHeightRazao": 1.4,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.36px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 24,
+            "maiorLarguraCh": 24,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 20,
+            "elementos": 4,
+            "caracteres": 74,
+            "palavras": 11,
+            "textos": [
+              "Aura Luxe — Scale Strategy",
+              "Market Fluidity",
+              "Integrated Ecosystems",
+              "Data Clarity"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "30px",
+            "lineHeightRazao": 1.5,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 20,
+            "maiorLarguraCh": 20,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "1/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 14,
+          "fontFamily": "Inter, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "19.6px",
+          "lineHeightRazao": 1.4,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 33
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            80,
+            40,
+            38,
+            36,
+            28,
+            24,
+            20
+          ],
+          "workhorse_semFiltro": {
+            "px": 14,
+            "ocorrencias": 5
+          },
+          "razao_semFiltro": 5.71,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 19,
+          "caracteresTotais": 357,
+          "caracteresPor1000px": 18.34,
+          "semNeutralizar": 19,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Inter Tight\", sans-serif",
+            "contagem": 54
+          },
+          {
+            "familia": "Inter, sans-serif",
+            "contagem": 6
+          },
+          {
+            "familia": "\"Funnel Display\", sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 80,
+          "tag": "div",
+          "className": "gsap_split_letter gsap_split_letter1",
+          "caracteres": 1,
+          "palavras": 1,
+          "fontFamily": "\"Funnel Display\", sans-serif",
+          "familiaEfetiva": "Funnel Display",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 94.3
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": true
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            80,
+            40,
+            38,
+            36,
+            28,
+            24
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            80,
+            40,
+            38,
+            36,
+            28,
+            24
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            80,
+            40,
+            38,
+            36,
+            28,
+            24
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            80,
+            40,
+            38,
+            36,
+            28,
+            24
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            80,
+            40,
+            38,
+            36,
+            28,
+            24,
+            20
+          ],
+          "maiorTexto": 80
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://aelixa.webflow.io"
+    },
+    "aelixa@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:19:40.484Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 20710,
+        "imgs": 81,
+        "carregadas": 58
+      },
+      "data": {
+        "url": "https://aelixa.webflow.io/",
+        "altura": 20710,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 116
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 20.2,
+        "telas_base900_legado": 23,
+        "metricaV2_hsvS015": 0.6,
+        "corPerceptivel_C005": 0.6,
+        "corForte_C012": 0.6,
+        "cromaMedioPonderado": 0.004,
+        "cromaPicoOklch": 0.153,
+        "fundos": [
+          {
+            "cor": "rgb(253,251,248)",
+            "pct": 65,
+            "L": 0.99,
+            "C": 0.005,
+            "H": 78
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 20.5,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(36,36,36)",
+            "pct": 13.4,
+            "L": 0.26,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(241,186,53)",
+            "pct": 0.6,
+            "L": 0.82,
+            "C": 0.153,
+            "H": 85
+          },
+          {
+            "cor": "rgb(51,51,51)",
+            "pct": 0.5,
+            "L": 0.32,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(35,35,35)",
+            "pct": 0,
+            "L": 0.26,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 81,
+          "svg": 91,
+          "video": 1,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 8.35,
+        "keyframes": 1,
+        "nomes": [
+          "spin"
+        ],
+        "keyframesPor1000": 0.05,
+        "folhasBloqueadas": 2,
+        "emTransicao": 74,
+        "emTransicaoPor1000": 3.57,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            54
+          ],
+          [
+            "0.35s",
+            20
+          ],
+          [
+            "0.4s",
+            2
+          ]
+        ],
+        "tamTitulos": [
+          120,
+          80,
+          60,
+          56,
+          36,
+          32,
+          28,
+          24
+        ],
+        "workhorse": {
+          "px": 18,
+          "ocorrencias": 5
+        },
+        "razaoTituloWorkhorse": 6.67,
+        "titulosDetalhes": [
+          {
+            "px": 120,
+            "elementos": 1,
+            "caracteres": 7,
+            "palavras": 1,
+            "textos": [
+              "aelixa."
+            ],
+            "fontFamily": "\"Funnel Display\", sans-serif",
+            "familiaEfetiva": "Funnel Display",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "funnel display",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "120px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-6px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 5,
+            "maiorLarguraCh": 5,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 80,
+            "elementos": 6,
+            "caracteres": 150,
+            "palavras": 30,
+            "textos": [
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -",
+              "KIND WORDS FROM CLIENTS -"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "96px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1.2px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 22,
+            "maiorLarguraCh": 22,
+            "fracaoContidaMin": 0.71,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 60,
+            "elementos": 9,
+            "caracteres": 144,
+            "palavras": 25,
+            "textos": [
+              "Services",
+              "GET STARTED TODAY",
+              "GET STARTED TODAY",
+              "GET STARTED TODAY",
+              "GET STARTED TODAY",
+              "GET STARTED TODAY"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "72px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.9px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 19,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 56,
+            "elementos": 12,
+            "caracteres": 279,
+            "palavras": 39,
+            "textos": [
+              "Your Next Best",
+              "Marketing",
+              "Decision",
+              "Starts Here",
+              "Strategy First.\nAlways.",
+              "Strategist-Led Built on Data"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "67.2px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 11,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 36,
+            "elementos": 12,
+            "caracteres": 118,
+            "palavras": 21,
+            "textos": [
+              "SEO Optimization",
+              "Performance Marketing",
+              "Content & Social",
+              "Strategy & Data",
+              "Marketing That Makes Sense",
+              "$799"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "50.4px",
+            "lineHeightRazao": 1.4,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 12,
+            "maiorLarguraCh": 26,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 32,
+            "elementos": 12,
+            "caracteres": 352,
+            "palavras": 56,
+            "textos": [
+              "3.8×",
+              "+240×",
+              "Aura Luxe — Scale Strategy",
+              "FinEdge — Performance UI/UX",
+              "Apex SaaS — Content & SEO",
+              "Vanguard — Digital Identity"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "44.8px",
+            "lineHeightRazao": 1.4,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 13,
+            "maiorLarguraCh": 35,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 28,
+            "elementos": 1,
+            "caracteres": 26,
+            "palavras": 5,
+            "textos": [
+              "Aura Luxe — Scale Strategy"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "42px",
+            "lineHeightRazao": 1.5,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 20,
+            "maiorLarguraCh": 20,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "1/5"
+          },
+          {
+            "px": 24,
+            "elementos": 3,
+            "caracteres": 48,
+            "palavras": 6,
+            "textos": [
+              "Market Fluidity",
+              "Integrated Ecosystems",
+              "Data Clarity"
+            ],
+            "fontFamily": "\"Inter Tight\", sans-serif",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "36px",
+            "lineHeightRazao": 1.5,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 11,
+            "maiorLarguraCh": 16,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "1/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 18,
+          "fontFamily": "Inter, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "27px",
+          "lineHeightRazao": 1.5,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 55
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            120,
+            80,
+            60,
+            56,
+            36,
+            32,
+            28,
+            24
+          ],
+          "workhorse_semFiltro": {
+            "px": 18,
+            "ocorrencias": 5
+          },
+          "razao_semFiltro": 6.67,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 19,
+          "caracteresTotais": 357,
+          "caracteresPor1000px": 17.24,
+          "semNeutralizar": 19,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Inter Tight\", sans-serif",
+            "contagem": 55
+          },
+          {
+            "familia": "Inter, sans-serif",
+            "contagem": 6
+          },
+          {
+            "familia": "\"Funnel Display\", sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 120,
+          "tag": "div",
+          "className": "gsap_split_letter gsap_split_letter1",
+          "caracteres": 1,
+          "palavras": 1,
+          "fontFamily": "\"Funnel Display\", sans-serif",
+          "familiaEfetiva": "Funnel Display",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 96.9
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": true
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            120,
+            80,
+            60,
+            56,
+            36,
+            32
+          ],
+          "maiorTexto": 120
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            120,
+            80,
+            60,
+            56,
+            36,
+            32
+          ],
+          "maiorTexto": 120
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            120,
+            80,
+            60,
+            56,
+            36,
+            32
+          ],
+          "maiorTexto": 120
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            120,
+            80,
+            60,
+            56,
+            36,
+            32
+          ],
+          "maiorTexto": 120
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            120,
+            80,
+            60,
+            56,
+            36,
+            32,
+            28,
+            24
+          ],
+          "maiorTexto": 120
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://aelixa.webflow.io"
+    },
+    "illoca@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:19:51.744Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 568,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "https://illoca.unseen.co/",
+        "altura": 568,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 28
+        },
+        "viewportMedido": {
+          "w": 320,
+          "h": 568,
+          "dpr": 2
+        },
+        "telas": 1,
+        "telas_base900_legado": 0.6,
+        "metricaV2_hsvS015": 10.9,
+        "corPerceptivel_C005": 10.9,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0.034,
+        "cromaPicoOklch": 0.109,
+        "fundos": [
+          {
+            "cor": "rgb(234,223,201)",
+            "pct": 68.8,
+            "L": 0.91,
+            "C": 0.032,
+            "H": 85
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 16.9,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(40,63,125)",
+            "pct": 10.9,
+            "L": 0.38,
+            "C": 0.109,
+            "H": 266
+          },
+          {
+            "cor": "rgb(253,248,240)",
+            "pct": 3.5,
+            "L": 0.98,
+            "C": 0.012,
+            "H": 80
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 49,
+          "video": 0,
+          "canvas": 1
+        },
+        "midiaTotalPor1000": 88.03,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 2,
+        "emTransicao": 15,
+        "emTransicaoPor1000": 26.41,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            5
+          ],
+          [
+            "0.5s",
+            5
+          ],
+          [
+            "0.2s",
+            2
+          ],
+          [
+            "0.15s",
+            2
+          ],
+          [
+            "0.1s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          47,
+          41,
+          24,
+          18,
+          12,
+          10
+        ],
+        "workhorse": {
+          "px": 10,
+          "ocorrencias": 22
+        },
+        "razaoTituloWorkhorse": 4.7,
+        "titulosDetalhes": [
+          {
+            "px": 47,
+            "elementos": 1,
+            "caracteres": 107,
+            "palavras": 21,
+            "textos": [
+              "Design at the speed of thought\nDesign at\nthe speed\nof thought\nDesign at\nthe speed\nof thought\nK\nnot\nsoftware"
+            ],
+            "fontFamily": "\"F37 Analog\", sans-serif",
+            "familiaEfetiva": "F37 Analog",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "f37 analog",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "42.6666px",
+            "lineHeightRazao": 0.91,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 41,
+            "elementos": 6,
+            "caracteres": 189,
+            "palavras": 23,
+            "textos": [
+              "Augmented Sketch\nAugmented Sketch",
+              "Adaptive Massing\nAdaptive Massing",
+              "Prompted Plans\nPrompted Plans",
+              "Agentic Refinement\nAgentic Refinement",
+              "Instant Facades\nInstant Facades",
+              "Frequently Asked Questions"
+            ],
+            "fontFamily": "\"F37 Analog\", sans-serif",
+            "familiaEfetiva": "F37 Analog",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "f37 analog",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "41.4814px",
+            "lineHeightRazao": 1.01,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 11,
+            "maiorLarguraCh": 11,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 24,
+            "elementos": 3,
+            "caracteres": 21,
+            "palavras": 3,
+            "textos": [
+              "Explore",
+              "Team",
+              "Enterprise"
+            ],
+            "fontFamily": "\"Graphik Web\", sans-serif",
+            "familiaEfetiva": "Graphik Web",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "graphik web",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "23.7037px",
+            "lineHeightRazao": 0.99,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.474074px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 15,
+            "maiorLarguraCh": 15,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 1,
+            "caracteres": 49,
+            "palavras": 9,
+            "textos": [
+              "Get 1,000 starter credits when you sign up today."
+            ],
+            "fontFamily": "\"Graphik Web\", sans-serif",
+            "familiaEfetiva": "Graphik Web",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "graphik web",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "17.7778px",
+            "lineHeightRazao": 0.99,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.355555px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 19,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 12,
+            "elementos": 5,
+            "caracteres": 70,
+            "palavras": 14,
+            "textos": [
+              "PRICING",
+              "$29.99 / person / month",
+              "$59.99+ / team / month",
+              "Custom pricing",
+              "FAQS"
+            ],
+            "fontFamily": "ui-sans-serif, system-ui, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\"",
+            "familiaEfetiva": "ui-sans-serif",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ui-sans-serif",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "17.7778px",
+            "lineHeightRazao": 1.48,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 18,
+            "maiorLarguraCh": 29,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 10,
+            "elementos": 2,
+            "caracteres": 18,
+            "palavras": 3,
+            "textos": [
+              "Quick links",
+              "Connect"
+            ],
+            "fontFamily": "\"Graphik Web\", sans-serif",
+            "familiaEfetiva": "Graphik Web",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "graphik web",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "15.5555px",
+            "lineHeightRazao": 1.56,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.207407px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 17,
+            "maiorLarguraCh": 17,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 10,
+          "fontFamily": "\"Graphik Web\", sans-serif",
+          "familiaEfetiva": "Graphik Web",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "11.4074px",
+          "lineHeightRazao": 1.14,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 34
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            47,
+            41,
+            24,
+            18,
+            12,
+            10
+          ],
+          "workhorse_semFiltro": {
+            "px": 12,
+            "ocorrencias": 24
+          },
+          "razao_semFiltro": 3.92,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 2,
+          "caracteresTotais": 11,
+          "caracteresPor1000px": 19.37,
+          "semNeutralizar": 2,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Graphik Web\", sans-serif",
+            "contagem": 41
+          },
+          {
+            "familia": "\"F37 Analog\", sans-serif",
+            "contagem": 7
+          },
+          {
+            "familia": "ui-sans-serif, system-ui, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\"",
+            "contagem": 2
+          },
+          {
+            "familia": "\"Geist Mono\", monospace",
+            "contagem": 2
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 47,
+          "tag": "span",
+          "className": "sr-only",
+          "caracteres": 30,
+          "palavras": 6,
+          "fontFamily": "\"F37 Analog\", sans-serif",
+          "familiaEfetiva": "F37 Analog",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "500",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 15.5
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            47,
+            41,
+            24,
+            18,
+            12,
+            10
+          ],
+          "maiorTexto": 47
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            47,
+            41,
+            24,
+            18,
+            12,
+            10
+          ],
+          "maiorTexto": 47
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            47,
+            41,
+            24,
+            18,
+            12,
+            10
+          ],
+          "maiorTexto": 47
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            47,
+            41,
+            24,
+            18,
+            12,
+            10
+          ],
+          "maiorTexto": 47
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            47,
+            41,
+            24,
+            18,
+            12,
+            10
+          ],
+          "maiorTexto": 47
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://illoca.unseen.co"
+    },
+    "illoca@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:20:02.073Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 844,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "https://illoca.unseen.co/",
+        "altura": 844,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 28
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 1,
+        "telas_base900_legado": 0.9,
+        "metricaV2_hsvS015": 9.7,
+        "corPerceptivel_C005": 9.7,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0.033,
+        "cromaPicoOklch": 0.109,
+        "fundos": [
+          {
+            "cor": "rgb(234,223,201)",
+            "pct": 68.7,
+            "L": 0.91,
+            "C": 0.032,
+            "H": 85
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 18.6,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(40,63,125)",
+            "pct": 9.7,
+            "L": 0.38,
+            "C": 0.109,
+            "H": 266
+          },
+          {
+            "cor": "rgb(253,248,240)",
+            "pct": 3,
+            "L": 0.98,
+            "C": 0.012,
+            "H": 80
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 49,
+          "video": 0,
+          "canvas": 1
+        },
+        "midiaTotalPor1000": 59.24,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 2,
+        "emTransicao": 15,
+        "emTransicaoPor1000": 17.77,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            5
+          ],
+          [
+            "0.5s",
+            5
+          ],
+          [
+            "0.2s",
+            2
+          ],
+          [
+            "0.15s",
+            2
+          ],
+          [
+            "0.1s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          58,
+          51,
+          29,
+          22,
+          14,
+          13
+        ],
+        "workhorse": {
+          "px": 13,
+          "ocorrencias": 23
+        },
+        "razaoTituloWorkhorse": 4.46,
+        "titulosDetalhes": [
+          {
+            "px": 58,
+            "elementos": 1,
+            "caracteres": 107,
+            "palavras": 21,
+            "textos": [
+              "Design at the speed of thought\nDesign at\nthe speed\nof thought\nDesign at\nthe speed\nof thought\nK\nnot\nsoftware"
+            ],
+            "fontFamily": "\"F37 Analog\", sans-serif",
+            "familiaEfetiva": "F37 Analog",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "f37 analog",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "52px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 51,
+            "elementos": 6,
+            "caracteres": 189,
+            "palavras": 23,
+            "textos": [
+              "Augmented Sketch\nAugmented Sketch",
+              "Adaptive Massing\nAdaptive Massing",
+              "Prompted Plans\nPrompted Plans",
+              "Agentic Refinement\nAgentic Refinement",
+              "Instant Facades\nInstant Facades",
+              "Frequently Asked Questions"
+            ],
+            "fontFamily": "\"F37 Analog\", sans-serif",
+            "familiaEfetiva": "F37 Analog",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "f37 analog",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "50.5555px",
+            "lineHeightRazao": 0.99,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 11,
+            "maiorLarguraCh": 11,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 29,
+            "elementos": 3,
+            "caracteres": 21,
+            "palavras": 3,
+            "textos": [
+              "Explore",
+              "Team",
+              "Enterprise"
+            ],
+            "fontFamily": "\"Graphik Web\", sans-serif",
+            "familiaEfetiva": "Graphik Web",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "graphik web",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "28.8889px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.577777px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 15,
+            "maiorLarguraCh": 15,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 22,
+            "elementos": 1,
+            "caracteres": 49,
+            "palavras": 9,
+            "textos": [
+              "Get 1,000 starter credits when you sign up today."
+            ],
+            "fontFamily": "\"Graphik Web\", sans-serif",
+            "familiaEfetiva": "Graphik Web",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "graphik web",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "21.6666px",
+            "lineHeightRazao": 0.98,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.433333px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 19,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 14,
+            "elementos": 5,
+            "caracteres": 70,
+            "palavras": 14,
+            "textos": [
+              "PRICING",
+              "$29.99 / person / month",
+              "$59.99+ / team / month",
+              "Custom pricing",
+              "FAQS"
+            ],
+            "fontFamily": "ui-sans-serif, system-ui, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\"",
+            "familiaEfetiva": "ui-sans-serif",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ui-sans-serif",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "21.6666px",
+            "lineHeightRazao": 1.55,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 18,
+            "maiorLarguraCh": 29,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 13,
+            "elementos": 2,
+            "caracteres": 18,
+            "palavras": 3,
+            "textos": [
+              "Quick links",
+              "Connect"
+            ],
+            "fontFamily": "\"Graphik Web\", sans-serif",
+            "familiaEfetiva": "Graphik Web",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "graphik web",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "18.9583px",
+            "lineHeightRazao": 1.46,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.252778px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 17,
+            "maiorLarguraCh": 17,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 13,
+          "fontFamily": "\"Graphik Web\", sans-serif",
+          "familiaEfetiva": "Graphik Web",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "13.9028px",
+          "lineHeightRazao": 1.07,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 34
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            58,
+            51,
+            29,
+            22,
+            14,
+            13
+          ],
+          "workhorse_semFiltro": {
+            "px": 14,
+            "ocorrencias": 24
+          },
+          "razao_semFiltro": 4.14,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 2,
+          "caracteresTotais": 11,
+          "caracteresPor1000px": 13.03,
+          "semNeutralizar": 2,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Graphik Web\", sans-serif",
+            "contagem": 41
+          },
+          {
+            "familia": "\"F37 Analog\", sans-serif",
+            "contagem": 7
+          },
+          {
+            "familia": "ui-sans-serif, system-ui, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\"",
+            "contagem": 2
+          },
+          {
+            "familia": "\"Geist Mono\", monospace",
+            "contagem": 2
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 58,
+          "tag": "span",
+          "className": "sr-only",
+          "caracteres": 30,
+          "palavras": 6,
+          "fontFamily": "\"F37 Analog\", sans-serif",
+          "familiaEfetiva": "F37 Analog",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "500",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 12.8
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            58,
+            51,
+            29,
+            22,
+            14,
+            13
+          ],
+          "maiorTexto": 58
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            58,
+            51,
+            29,
+            22,
+            14,
+            13
+          ],
+          "maiorTexto": 58
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            58,
+            51,
+            29,
+            22,
+            14,
+            13
+          ],
+          "maiorTexto": 58
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            58,
+            51,
+            29,
+            22,
+            14,
+            13
+          ],
+          "maiorTexto": 58
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            58,
+            51,
+            29,
+            22,
+            14,
+            13
+          ],
+          "maiorTexto": 58
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://illoca.unseen.co"
+    },
+    "illoca@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:20:12.425Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 1024,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "https://illoca.unseen.co/",
+        "altura": 1024,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 28
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 1,
+        "telas_base900_legado": 1.1,
+        "metricaV2_hsvS015": 12.1,
+        "corPerceptivel_C005": 11.8,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0.035,
+        "cromaPicoOklch": 0.109,
+        "fundos": [
+          {
+            "cor": "rgb(234,223,201)",
+            "pct": 68.2,
+            "L": 0.91,
+            "C": 0.032,
+            "H": 85
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 17,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(40,63,125)",
+            "pct": 11.8,
+            "L": 0.38,
+            "C": 0.109,
+            "H": 266
+          },
+          {
+            "cor": "rgb(253,248,240)",
+            "pct": 2.7,
+            "L": 0.98,
+            "C": 0.012,
+            "H": 80
+          },
+          {
+            "cor": "rgb(229,214,188)",
+            "pct": 0.2,
+            "L": 0.88,
+            "C": 0.038,
+            "H": 81
+          },
+          {
+            "cor": "rgb(91,91,91)",
+            "pct": 0.1,
+            "L": 0.47,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 49,
+          "video": 0,
+          "canvas": 1
+        },
+        "midiaTotalPor1000": 48.83,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 2,
+        "emTransicao": 15,
+        "emTransicaoPor1000": 14.65,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            5
+          ],
+          [
+            "0.5s",
+            5
+          ],
+          [
+            "0.2s",
+            2
+          ],
+          [
+            "0.15s",
+            2
+          ],
+          [
+            "0.1s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          105,
+          81,
+          47,
+          35,
+          23,
+          20
+        ],
+        "workhorse": {
+          "px": 20,
+          "ocorrencias": 22
+        },
+        "razaoTituloWorkhorse": 5.25,
+        "titulosDetalhes": [
+          {
+            "px": 105,
+            "elementos": 1,
+            "caracteres": 107,
+            "palavras": 21,
+            "textos": [
+              "Design at the speed of thought\nDesign at\nthe speed\nof thought\nDesign at\nthe speed\nof thought\nK\nnot\nsoftware"
+            ],
+            "fontFamily": "\"F37 Analog\", sans-serif",
+            "familiaEfetiva": "F37 Analog",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "f37 analog",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "94.2545px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 8,
+            "maiorLarguraCh": 8,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 81,
+            "elementos": 6,
+            "caracteres": 189,
+            "palavras": 23,
+            "textos": [
+              "Augmented Sketch\nAugmented Sketch",
+              "Adaptive Massing\nAdaptive Massing",
+              "Prompted Plans\nPrompted Plans",
+              "Agentic Refinement\nAgentic Refinement",
+              "Instant Facades\nInstant Facades",
+              "Frequently Asked Questions"
+            ],
+            "fontFamily": "\"F37 Analog\", sans-serif",
+            "familiaEfetiva": "F37 Analog",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "f37 analog",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "81.4545px",
+            "lineHeightRazao": 1.01,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 14,
+            "maiorLarguraCh": 14,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 47,
+            "elementos": 3,
+            "caracteres": 21,
+            "palavras": 3,
+            "textos": [
+              "Explore",
+              "Team",
+              "Enterprise"
+            ],
+            "fontFamily": "\"Graphik Web\", sans-serif",
+            "familiaEfetiva": "Graphik Web",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "graphik web",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "46.5454px",
+            "lineHeightRazao": 0.99,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.930908px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 19,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 35,
+            "elementos": 1,
+            "caracteres": 49,
+            "palavras": 9,
+            "textos": [
+              "Get 1,000 starter credits when you sign up today."
+            ],
+            "fontFamily": "\"Graphik Web\", sans-serif",
+            "familiaEfetiva": "Graphik Web",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "graphik web",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "34.9091px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.698181px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 19,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 23,
+            "elementos": 5,
+            "caracteres": 70,
+            "palavras": 14,
+            "textos": [
+              "PRICING",
+              "$29.99 / person / month",
+              "$59.99+ / team / month",
+              "Custom pricing",
+              "FAQS"
+            ],
+            "fontFamily": "ui-sans-serif, system-ui, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\"",
+            "familiaEfetiva": "ui-sans-serif",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ui-sans-serif",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "34.9091px",
+            "lineHeightRazao": 1.52,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 18,
+            "maiorLarguraCh": 38,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 20,
+            "elementos": 2,
+            "caracteres": 18,
+            "palavras": 3,
+            "textos": [
+              "Quick links",
+              "Connect"
+            ],
+            "fontFamily": "\"Graphik Web\", sans-serif",
+            "familiaEfetiva": "Graphik Web",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "graphik web",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "30.5454px",
+            "lineHeightRazao": 1.53,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.407272px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 21,
+            "maiorLarguraCh": 21,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 20,
+          "fontFamily": "\"Graphik Web\", sans-serif",
+          "familiaEfetiva": "Graphik Web",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "22.4px",
+          "lineHeightRazao": 1.12,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 44
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            105,
+            81,
+            47,
+            35,
+            23,
+            20
+          ],
+          "workhorse_semFiltro": {
+            "px": 23,
+            "ocorrencias": 24
+          },
+          "razao_semFiltro": 4.57,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 2,
+          "caracteresTotais": 11,
+          "caracteresPor1000px": 10.74,
+          "semNeutralizar": 2,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Graphik Web\", sans-serif",
+            "contagem": 41
+          },
+          {
+            "familia": "\"F37 Analog\", sans-serif",
+            "contagem": 7
+          },
+          {
+            "familia": "ui-sans-serif, system-ui, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\", \"Noto Color Emoji\"",
+            "contagem": 2
+          },
+          {
+            "familia": "\"Geist Mono\", monospace",
+            "contagem": 2
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 105,
+          "tag": "span",
+          "className": "sr-only",
+          "caracteres": 30,
+          "palavras": 6,
+          "fontFamily": "\"F37 Analog\", sans-serif",
+          "familiaEfetiva": "F37 Analog",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "500",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 17
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            105,
+            81,
+            47,
+            35,
+            23,
+            20
+          ],
+          "maiorTexto": 105
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            105,
+            81,
+            47,
+            35,
+            23,
+            20
+          ],
+          "maiorTexto": 105
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            105,
+            81,
+            47,
+            35,
+            23,
+            20
+          ],
+          "maiorTexto": 105
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            105,
+            81,
+            47,
+            35,
+            23,
+            20
+          ],
+          "maiorTexto": 105
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            105,
+            81,
+            47,
+            35,
+            23,
+            20
+          ],
+          "maiorTexto": 105
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://illoca.unseen.co"
+    },
+    "paulkalkbrenner@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:20:28.845Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 7615,
+        "imgs": 83,
+        "carregadas": 54
+      },
+      "data": {
+        "url": "https://www.paulkalkbrenner.net/",
+        "altura": 7615,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 2
+        },
+        "viewportMedido": {
+          "w": 320,
+          "h": 568,
+          "dpr": 2
+        },
+        "telas": 13.4,
+        "telas_base900_legado": 8.5,
+        "metricaV2_hsvS015": 11.1,
+        "corPerceptivel_C005": 11.1,
+        "corForte_C012": 11.1,
+        "cromaMedioPonderado": 0.02,
+        "cromaPicoOklch": 0.196,
+        "fundos": [
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 41.8,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 36.3,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(197,197,197)",
+            "pct": 10.8,
+            "L": 0.82,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(167,255,156)",
+            "pct": 5.8,
+            "L": 0.92,
+            "C": 0.156,
+            "H": 142
+          },
+          {
+            "cor": "rgb(255,104,49)",
+            "pct": 5.4,
+            "L": 0.7,
+            "C": 0.196,
+            "H": 39
+          }
+        ],
+        "midia": {
+          "img": 83,
+          "svg": 3,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 11.29,
+        "keyframes": 1,
+        "nomes": [
+          "spin"
+        ],
+        "keyframesPor1000": 0.13,
+        "folhasBloqueadas": 1,
+        "emTransicao": 359,
+        "emTransicaoPor1000": 47.14,
+        "animacoesAtivas": 2,
+        "duracoes": [
+          [
+            "0.3s",
+            295
+          ],
+          [
+            "0.1s",
+            294
+          ],
+          [
+            "0.35s",
+            20
+          ],
+          [
+            "0.55s",
+            14
+          ],
+          [
+            "0.2s",
+            13
+          ],
+          [
+            "0.4s",
+            10
+          ],
+          [
+            "1s",
+            8
+          ],
+          [
+            "0.7s",
+            2
+          ]
+        ],
+        "tamTitulos": [
+          49,
+          39,
+          33,
+          20,
+          11
+        ],
+        "workhorse": {
+          "px": 13,
+          "ocorrencias": 15
+        },
+        "razaoTituloWorkhorse": 3.77,
+        "titulosDetalhes": [
+          {
+            "px": 49,
+            "elementos": 6,
+            "caracteres": 35,
+            "palavras": 6,
+            "textos": [
+              "Experience",
+              "the",
+              "Pulse",
+              "of",
+              "Electronic",
+              "Music"
+            ],
+            "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "familiaEfetiva": "ABC Diatype Plus Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "abc diatype plus variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "39.3846px",
+            "lineHeightRazao": 0.8,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-2.46154px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 8,
+            "maiorLarguraCh": 8,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 39,
+            "elementos": 1,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "Paul\nKalkbrenner"
+            ],
+            "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "familiaEfetiva": "ABC Diatype Plus Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "abc diatype plus variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "31.5077px",
+            "lineHeightRazao": 0.81,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1.96923px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 13,
+            "maiorLarguraCh": 13,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 33,
+            "elementos": 1,
+            "caracteres": 82,
+            "palavras": 13,
+            "textos": [
+              "Join the newsletter for exclusive updates on new music, tours and special content."
+            ],
+            "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "familiaEfetiva": "ABC Diatype Plus Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "abc diatype plus variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "29.5385px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.65641px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 15,
+            "maiorLarguraCh": 15,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 20,
+            "elementos": 7,
+            "caracteres": 71,
+            "palavras": 11,
+            "textos": [
+              "RECORDINGS",
+              "THE ESSENCE",
+              "TOUR DATES",
+              "GALLERY",
+              "VIDEO ARCHIVE",
+              "LIFE WORKS"
+            ],
+            "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "familiaEfetiva": "ABC Diatype Plus Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "abc diatype plus variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "17.7231px",
+            "lineHeightRazao": 0.89,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.393846px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 10,
+            "maiorLarguraCh": 12,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 11,
+            "elementos": 3,
+            "caracteres": 18,
+            "palavras": 3,
+            "textos": [
+              "LINKS",
+              "SUPPORT",
+              "FOLLOW"
+            ],
+            "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "familiaEfetiva": "ABC Diatype Plus Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "abc diatype plus variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "10.3385px",
+            "lineHeightRazao": 0.94,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.229744px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 9,
+            "maiorLarguraCh": 10,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 13,
+          "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+          "familiaEfetiva": "ABC Diatype Plus Variable",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "19.6923px",
+          "lineHeightRazao": 1.51,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 19
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            49,
+            39,
+            33,
+            20,
+            11
+          ],
+          "workhorse_semFiltro": {
+            "px": 15,
+            "ocorrencias": 90
+          },
+          "razao_semFiltro": 3.27,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": [
+            {
+              "px": 142,
+              "tag": "span",
+              "fracaoContida": 0.05,
+              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+            },
+            {
+              "px": 142,
+              "tag": "span",
+              "fracaoContida": 0.05,
+              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+            },
+            {
+              "px": 142,
+              "tag": "span",
+              "fracaoContida": 0.05,
+              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+            },
+            {
+              "px": 142,
+              "tag": "span",
+              "fracaoContida": 0.05,
+              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+            }
+          ]
+        },
+        "caixaAlta": {
+          "elementos": 160,
+          "caracteresTotais": 539,
+          "caracteresPor1000px": 70.78,
+          "semNeutralizar": 160,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "contagem": 48
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 116,
+          "tag": "span",
+          "className": "",
+          "caracteres": 2,
+          "palavras": 1,
+          "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+          "familiaEfetiva": "ABC Diatype Plus Variable",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 66.9
+        },
+        "pontoCego": true,
+        "diferencaPx": 67,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            49,
+            39,
+            33,
+            20,
+            11
+          ],
+          "maiorTexto": 116
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            49,
+            39,
+            33,
+            20,
+            11
+          ],
+          "maiorTexto": 116
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            49,
+            39,
+            33,
+            20,
+            11
+          ],
+          "maiorTexto": 116
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            49,
+            39,
+            33,
+            20,
+            11
+          ],
+          "maiorTexto": 116
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            49,
+            39,
+            33,
+            20,
+            11
+          ],
+          "maiorTexto": 116
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://paulkalkbrenner.net"
+    },
+    "paulkalkbrenner@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:20:45.843Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 9431,
+        "imgs": 83,
+        "carregadas": 55
+      },
+      "data": {
+        "url": "https://www.paulkalkbrenner.net/",
+        "altura": 9431,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 2
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 11.2,
+        "telas_base900_legado": 10.5,
+        "metricaV2_hsvS015": 11,
+        "corPerceptivel_C005": 11,
+        "corForte_C012": 11,
+        "cromaMedioPonderado": 0.019,
+        "cromaPicoOklch": 0.196,
+        "fundos": [
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 41.9,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 36.4,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(197,197,197)",
+            "pct": 10.7,
+            "L": 0.82,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(167,255,156)",
+            "pct": 5.7,
+            "L": 0.92,
+            "C": 0.156,
+            "H": 142
+          },
+          {
+            "cor": "rgb(255,104,49)",
+            "pct": 5.3,
+            "L": 0.7,
+            "C": 0.196,
+            "H": 39
+          }
+        ],
+        "midia": {
+          "img": 83,
+          "svg": 3,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 9.12,
+        "keyframes": 1,
+        "nomes": [
+          "spin"
+        ],
+        "keyframesPor1000": 0.11,
+        "folhasBloqueadas": 1,
+        "emTransicao": 359,
+        "emTransicaoPor1000": 38.07,
+        "animacoesAtivas": 2,
+        "duracoes": [
+          [
+            "0.3s",
+            295
+          ],
+          [
+            "0.1s",
+            294
+          ],
+          [
+            "0.35s",
+            20
+          ],
+          [
+            "0.55s",
+            14
+          ],
+          [
+            "0.2s",
+            13
+          ],
+          [
+            "0.4s",
+            10
+          ],
+          [
+            "1s",
+            8
+          ],
+          [
+            "0.7s",
+            2
+          ]
+        ],
+        "tamTitulos": [
+          60,
+          48,
+          40,
+          24,
+          14
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 15
+        },
+        "razaoTituloWorkhorse": 3.75,
+        "titulosDetalhes": [
+          {
+            "px": 60,
+            "elementos": 6,
+            "caracteres": 35,
+            "palavras": 6,
+            "textos": [
+              "Experience",
+              "the",
+              "Pulse",
+              "of",
+              "Electronic",
+              "Music"
+            ],
+            "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "familiaEfetiva": "ABC Diatype Plus Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "abc diatype plus variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "48px",
+            "lineHeightRazao": 0.8,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-3px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 8,
+            "maiorLarguraCh": 8,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 48,
+            "elementos": 1,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "Paul\nKalkbrenner"
+            ],
+            "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "familiaEfetiva": "ABC Diatype Plus Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "abc diatype plus variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "38.4px",
+            "lineHeightRazao": 0.8,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-2.4px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 13,
+            "maiorLarguraCh": 13,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 40,
+            "elementos": 1,
+            "caracteres": 82,
+            "palavras": 13,
+            "textos": [
+              "Join the newsletter for exclusive updates on new music, tours and special content."
+            ],
+            "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "familiaEfetiva": "ABC Diatype Plus Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "abc diatype plus variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "36px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.8px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 15,
+            "maiorLarguraCh": 15,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 24,
+            "elementos": 7,
+            "caracteres": 71,
+            "palavras": 11,
+            "textos": [
+              "RECORDINGS",
+              "THE ESSENCE",
+              "TOUR DATES",
+              "GALLERY",
+              "VIDEO ARCHIVE",
+              "LIFE WORKS"
+            ],
+            "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "familiaEfetiva": "ABC Diatype Plus Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "abc diatype plus variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "21.6px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.48px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 10,
+            "maiorLarguraCh": 12,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 14,
+            "elementos": 3,
+            "caracteres": 18,
+            "palavras": 3,
+            "textos": [
+              "LINKS",
+              "SUPPORT",
+              "FOLLOW"
+            ],
+            "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "familiaEfetiva": "ABC Diatype Plus Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "abc diatype plus variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "12.6px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.28px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 9,
+            "maiorLarguraCh": 10,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+          "familiaEfetiva": "ABC Diatype Plus Variable",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "24px",
+          "lineHeightRazao": 1.5,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 19
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            60,
+            48,
+            40,
+            24,
+            14
+          ],
+          "workhorse_semFiltro": {
+            "px": 18,
+            "ocorrencias": 90
+          },
+          "razao_semFiltro": 3.33,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 160,
+          "caracteresTotais": 539,
+          "caracteresPor1000px": 57.15,
+          "semNeutralizar": 160,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "contagem": 48
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 174,
+          "tag": "span",
+          "className": "",
+          "caracteres": 1,
+          "palavras": 1,
+          "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+          "familiaEfetiva": "ABC Diatype Plus Variable",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "400",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 79.1
+        },
+        "pontoCego": true,
+        "diferencaPx": 114,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            60,
+            48,
+            40,
+            24,
+            14
+          ],
+          "maiorTexto": 141
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            60,
+            48,
+            40,
+            24,
+            14
+          ],
+          "maiorTexto": 141
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            60,
+            48,
+            40,
+            24,
+            14
+          ],
+          "maiorTexto": 141
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            60,
+            48,
+            40,
+            24,
+            14
+          ],
+          "maiorTexto": 141
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            60,
+            48,
+            40,
+            24,
+            14
+          ],
+          "maiorTexto": 174
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://paulkalkbrenner.net"
+    },
+    "paulkalkbrenner@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:20:59.938Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 7666,
+        "imgs": 83,
+        "carregadas": 63
+      },
+      "data": {
+        "url": "https://www.paulkalkbrenner.net/",
+        "altura": 7666,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 2
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 7.5,
+        "telas_base900_legado": 8.5,
+        "metricaV2_hsvS015": 10.1,
+        "corPerceptivel_C005": 10.1,
+        "corForte_C012": 10.1,
+        "cromaMedioPonderado": 0.017,
+        "cromaPicoOklch": 0.196,
+        "fundos": [
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 43.2,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 38.3,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(197,197,197)",
+            "pct": 8.4,
+            "L": 0.82,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(167,255,156)",
+            "pct": 6.7,
+            "L": 0.92,
+            "C": 0.156,
+            "H": 142
+          },
+          {
+            "cor": "rgb(255,104,49)",
+            "pct": 3.4,
+            "L": 0.7,
+            "C": 0.196,
+            "H": 39
+          }
+        ],
+        "midia": {
+          "img": 83,
+          "svg": 3,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 11.22,
+        "keyframes": 1,
+        "nomes": [
+          "spin"
+        ],
+        "keyframesPor1000": 0.13,
+        "folhasBloqueadas": 1,
+        "emTransicao": 359,
+        "emTransicaoPor1000": 46.83,
+        "animacoesAtivas": 2,
+        "duracoes": [
+          [
+            "0.3s",
+            295
+          ],
+          [
+            "0.1s",
+            294
+          ],
+          [
+            "0.35s",
+            20
+          ],
+          [
+            "0.55s",
+            14
+          ],
+          [
+            "0.2s",
+            13
+          ],
+          [
+            "0.4s",
+            10
+          ],
+          [
+            "1s",
+            8
+          ],
+          [
+            "0.7s",
+            2
+          ]
+        ],
+        "tamTitulos": [
+          88,
+          26,
+          13,
+          8
+        ],
+        "workhorse": {
+          "px": 9,
+          "ocorrencias": 23
+        },
+        "razaoTituloWorkhorse": 9.78,
+        "titulosDetalhes": [
+          {
+            "px": 88,
+            "elementos": 7,
+            "caracteres": 51,
+            "palavras": 8,
+            "textos": [
+              "Paul\nKalkbrenner",
+              "Experience",
+              "the",
+              "Pulse",
+              "of",
+              "Electronic"
+            ],
+            "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "familiaEfetiva": "ABC Diatype Plus Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "abc diatype plus variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "70.2171px",
+            "lineHeightRazao": 0.8,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-4.38857px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 13,
+            "maiorLarguraCh": 13,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 26,
+            "elementos": 1,
+            "caracteres": 82,
+            "palavras": 13,
+            "textos": [
+              "Join the newsletter for exclusive updates on new music, tours and special content."
+            ],
+            "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "familiaEfetiva": "ABC Diatype Plus Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "abc diatype plus variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "23.6983px",
+            "lineHeightRazao": 0.91,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.526629px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 23,
+            "maiorLarguraCh": 23,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 13,
+            "elementos": 7,
+            "caracteres": 71,
+            "palavras": 11,
+            "textos": [
+              "RECORDINGS",
+              "THE ESSENCE",
+              "TOUR DATES",
+              "GALLERY",
+              "VIDEO ARCHIVE",
+              "LIFE WORKS"
+            ],
+            "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "familiaEfetiva": "ABC Diatype Plus Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "abc diatype plus variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "11.8491px",
+            "lineHeightRazao": 0.91,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.263314px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 10,
+            "maiorLarguraCh": 12,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 8,
+            "elementos": 3,
+            "caracteres": 18,
+            "palavras": 3,
+            "textos": [
+              "LINKS",
+              "SUPPORT",
+              "FOLLOW"
+            ],
+            "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "familiaEfetiva": "ABC Diatype Plus Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "abc diatype plus variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "6.912px",
+            "lineHeightRazao": 0.86,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.1536px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 16,
+            "maiorLarguraCh": 16,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 9,
+          "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+          "familiaEfetiva": "ABC Diatype Plus Variable",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "8.77714px",
+          "lineHeightRazao": 0.98,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 19
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            88,
+            26,
+            13,
+            8
+          ],
+          "workhorse_semFiltro": {
+            "px": 10,
+            "ocorrencias": 90
+          },
+          "razao_semFiltro": 8.8,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": [
+            {
+              "px": 342,
+              "tag": "span",
+              "fracaoContida": 0.05,
+              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+            },
+            {
+              "px": 342,
+              "tag": "span",
+              "fracaoContida": 0.05,
+              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+            },
+            {
+              "px": 342,
+              "tag": "span",
+              "fracaoContida": 0.05,
+              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+            },
+            {
+              "px": 342,
+              "tag": "span",
+              "fracaoContida": 0.05,
+              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+            }
+          ]
+        },
+        "caixaAlta": {
+          "elementos": 183,
+          "caracteresTotais": 798,
+          "caracteresPor1000px": 104.1,
+          "semNeutralizar": 183,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+            "contagem": 56
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 88,
+          "tag": "span",
+          "className": "h-d__span",
+          "caracteres": 4,
+          "palavras": 1,
+          "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
+          "familiaEfetiva": "ABC Diatype Plus Variable",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 6
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            88,
+            26,
+            13,
+            8
+          ],
+          "maiorTexto": 88
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            88,
+            26,
+            13,
+            8
+          ],
+          "maiorTexto": 88
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            88,
+            26,
+            13,
+            8
+          ],
+          "maiorTexto": 88
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            88,
+            26,
+            13,
+            8
+          ],
+          "maiorTexto": 88
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            88,
+            26,
+            13,
+            8
+          ],
+          "maiorTexto": 88
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://paulkalkbrenner.net"
+    },
+    "lxlcreative@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:21:15.241Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 10652,
+        "imgs": 39,
+        "carregadas": 34
+      },
+      "data": {
+        "url": "https://www.lxlcreative.co.uk/",
+        "altura": 10652,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 6
+        },
+        "viewportMedido": {
+          "w": 320,
+          "h": 568,
+          "dpr": 2
+        },
+        "telas": 18.8,
+        "telas_base900_legado": 11.8,
+        "metricaV2_hsvS015": 97,
+        "corPerceptivel_C005": 1.6,
+        "corForte_C012": 1.5,
+        "cromaMedioPonderado": 0.015,
+        "cromaPicoOklch": 0.251,
+        "fundos": [
+          {
+            "cor": "rgb(39,32,29)",
+            "pct": 95.5,
+            "L": 0.25,
+            "C": 0.012,
+            "H": 45
+          },
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 2.2,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          },
+          {
+            "cor": "rgb(5,93,255)",
+            "pct": 1.2,
+            "L": 0.55,
+            "C": 0.251,
+            "H": 262
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 0.8,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,81,33)",
+            "pct": 0.2,
+            "L": 0.67,
+            "C": 0.218,
+            "H": 35
+          },
+          {
+            "cor": "rgb(252,242,189)",
+            "pct": 0.1,
+            "L": 0.96,
+            "C": 0.069,
+            "H": 99
+          }
+        ],
+        "midia": {
+          "img": 39,
+          "svg": 54,
+          "video": 2,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 8.92,
+        "keyframes": 1,
+        "nomes": [
+          "spin"
+        ],
+        "keyframesPor1000": 0.09,
+        "folhasBloqueadas": 1,
+        "emTransicao": 83,
+        "emTransicaoPor1000": 7.79,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.5s",
+            23
+          ],
+          [
+            "0.3s",
+            18
+          ],
+          [
+            "0.15s",
+            14
+          ],
+          [
+            "0.2s",
+            13
+          ],
+          [
+            "0.25s",
+            6
+          ],
+          [
+            "0.35s",
+            5
+          ],
+          [
+            "0.6s",
+            4
+          ],
+          [
+            "0.4s",
+            4
+          ]
+        ],
+        "tamTitulos": [
+          64,
+          32,
+          28,
+          20,
+          14
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 7
+        },
+        "razaoTituloWorkhorse": 4,
+        "titulosDetalhes": [
+          {
+            "px": 64,
+            "elementos": 2,
+            "caracteres": 14,
+            "palavras": 3,
+            "textos": [
+              "Why lxl",
+              "Studios"
+            ],
+            "fontFamily": "Scribo, Georgia, sans-serif",
+            "familiaEfetiva": "Scribo",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "scribo",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "400",
+            "lineHeightPx": "57.6px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 32,
+            "elementos": 4,
+            "caracteres": 113,
+            "palavras": 18,
+            "textos": [
+              "REAL CRAFT.\n‍Real people.‍",
+              "REAL RESULTS.",
+              "Our SERVICES",
+              "GOT A PRODUCTION COMING UP? LET’S DO SOMETHING great TOGETHER."
+            ],
+            "fontFamily": "\"Owners Wide\", Impact, sans-serif",
+            "familiaEfetiva": "Owners Wide",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "owners wide",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "28.8px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 10,
+            "maiorLarguraCh": 10,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 28,
+            "elementos": 1,
+            "caracteres": 37,
+            "palavras": 6,
+            "textos": [
+              "WHERE BRANDS, MUSIC AND CULTURE MEET."
+            ],
+            "fontFamily": "\"Owners Wide\", Impact, sans-serif",
+            "familiaEfetiva": "Owners Wide",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "owners wide",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "28px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 20,
+            "elementos": 7,
+            "caracteres": 89,
+            "palavras": 14,
+            "textos": [
+              "ACTIVATIONS",
+              "EDITORIAL",
+              "EPK",
+              "UNIT",
+              "SOCIAL CAMPAIGNS",
+              "KEY ART"
+            ],
+            "fontFamily": "\"Owners Wide\", Impact, sans-serif",
+            "familiaEfetiva": "Owners Wide",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "owners wide",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "20px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 4,
+            "maiorLarguraCh": 20,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 14,
+            "elementos": 4,
+            "caracteres": 66,
+            "palavras": 13,
+            "textos": [
+              "WHY LXL",
+              "WE’RE COLLABORATIVE",
+              "WE’RE UPFRONT & HONEST",
+              "WE LOVE WHAT WE DO"
+            ],
+            "fontFamily": "\"Owners Wide\", Impact, sans-serif",
+            "familiaEfetiva": "Owners Wide",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "owners wide",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "16.8px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 6,
+            "maiorLarguraCh": 18,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "Manrope, Arial, sans-serif",
+          "familiaEfetiva": "Manrope",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "22.4px",
+          "lineHeightRazao": 1.4,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 28
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            64,
+            32,
+            28,
+            20,
+            14
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 26
+          },
+          "razao_semFiltro": 4,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 36,
+          "caracteresTotais": 1153,
+          "caracteresPor1000px": 108.24,
+          "semNeutralizar": 32,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Owners Wide\", Impact, sans-serif",
+            "contagem": 16
+          },
+          {
+            "familia": "Manrope, Arial, sans-serif",
+            "contagem": 9
+          },
+          {
+            "familia": "Scribo, Georgia, sans-serif",
+            "contagem": 2
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 64,
+          "tag": "h2",
+          "className": "feature-pills_heading u-text-style-display-accent",
+          "caracteres": 7,
+          "palavras": 2,
+          "fontFamily": "Scribo, Georgia, sans-serif",
+          "familiaEfetiva": "Scribo",
+          "familiaVerificada": true,
+          "serifa": true,
+          "fontWeight": "400",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 72.9
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            64,
+            32,
+            28,
+            20,
+            14
+          ],
+          "maiorTexto": 64
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            64,
+            32,
+            28,
+            20,
+            14
+          ],
+          "maiorTexto": 64
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            64,
+            32,
+            28,
+            20,
+            14
+          ],
+          "maiorTexto": 64
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            64,
+            32,
+            28,
+            20,
+            14
+          ],
+          "maiorTexto": 64
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            64,
+            32,
+            28,
+            20,
+            14
+          ],
+          "maiorTexto": 64
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://lxlcreative.co.uk"
+    },
+    "lxlcreative@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:21:29.239Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 13316,
+        "imgs": 39,
+        "carregadas": 34
+      },
+      "data": {
+        "url": "https://www.lxlcreative.co.uk/",
+        "altura": 13316,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 6
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 15.8,
+        "telas_base900_legado": 14.8,
+        "metricaV2_hsvS015": 97,
+        "corPerceptivel_C005": 1.2,
+        "corForte_C012": 1.1,
+        "cromaMedioPonderado": 0.014,
+        "cromaPicoOklch": 0.251,
+        "fundos": [
+          {
+            "cor": "rgb(39,32,29)",
+            "pct": 95.8,
+            "L": 0.25,
+            "C": 0.012,
+            "H": 45
+          },
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 2.4,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          },
+          {
+            "cor": "rgb(5,93,255)",
+            "pct": 1,
+            "L": 0.55,
+            "C": 0.251,
+            "H": 262
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 0.6,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,81,33)",
+            "pct": 0.2,
+            "L": 0.67,
+            "C": 0.218,
+            "H": 35
+          },
+          {
+            "cor": "rgb(252,242,189)",
+            "pct": 0,
+            "L": 0.96,
+            "C": 0.069,
+            "H": 99
+          }
+        ],
+        "midia": {
+          "img": 39,
+          "svg": 54,
+          "video": 2,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 7.13,
+        "keyframes": 1,
+        "nomes": [
+          "spin"
+        ],
+        "keyframesPor1000": 0.08,
+        "folhasBloqueadas": 1,
+        "emTransicao": 83,
+        "emTransicaoPor1000": 6.23,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.5s",
+            23
+          ],
+          [
+            "0.3s",
+            18
+          ],
+          [
+            "0.15s",
+            14
+          ],
+          [
+            "0.2s",
+            13
+          ],
+          [
+            "0.25s",
+            6
+          ],
+          [
+            "0.35s",
+            5
+          ],
+          [
+            "0.6s",
+            4
+          ],
+          [
+            "0.4s",
+            4
+          ]
+        ],
+        "tamTitulos": [
+          64,
+          33,
+          29,
+          21,
+          20,
+          14
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 7
+        },
+        "razaoTituloWorkhorse": 4,
+        "titulosDetalhes": [
+          {
+            "px": 64,
+            "elementos": 2,
+            "caracteres": 14,
+            "palavras": 3,
+            "textos": [
+              "Why lxl",
+              "Studios"
+            ],
+            "fontFamily": "Scribo, Georgia, sans-serif",
+            "familiaEfetiva": "Scribo",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "scribo",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "400",
+            "lineHeightPx": "57.6px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 33,
+            "elementos": 4,
+            "caracteres": 113,
+            "palavras": 18,
+            "textos": [
+              "REAL CRAFT.\n‍Real people.‍",
+              "REAL RESULTS.",
+              "Our SERVICES",
+              "GOT A PRODUCTION COMING UP? LET’S DO SOMETHING great TOGETHER."
+            ],
+            "fontFamily": "\"Owners Wide\", Impact, sans-serif",
+            "familiaEfetiva": "Owners Wide",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "owners wide",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "30.0861px",
+            "lineHeightRazao": 0.91,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 12,
+            "maiorLarguraCh": 12,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 29,
+            "elementos": 1,
+            "caracteres": 37,
+            "palavras": 6,
+            "textos": [
+              "WHERE BRANDS, MUSIC AND CULTURE MEET."
+            ],
+            "fontFamily": "\"Owners Wide\", Impact, sans-serif",
+            "familiaEfetiva": "Owners Wide",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "owners wide",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "28.8935px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 10,
+            "maiorLarguraCh": 10,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 21,
+            "elementos": 1,
+            "caracteres": 39,
+            "palavras": 6,
+            "textos": [
+              "Discover some of our favourite projects"
+            ],
+            "fontFamily": "Manrope, Arial, sans-serif",
+            "familiaEfetiva": "Manrope",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "manrope",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "20.5355px",
+            "lineHeightRazao": 0.98,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 20,
+            "maiorLarguraCh": 20,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 20,
+            "elementos": 6,
+            "caracteres": 50,
+            "palavras": 8,
+            "textos": [
+              "ACTIVATIONS",
+              "EDITORIAL",
+              "EPK",
+              "UNIT",
+              "SOCIAL CAMPAIGNS",
+              "KEY ART"
+            ],
+            "fontFamily": "\"Owners Wide\", Impact, sans-serif",
+            "familiaEfetiva": "Owners Wide",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "owners wide",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "20.179px",
+            "lineHeightRazao": 1.01,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 5,
+            "maiorLarguraCh": 5,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 14,
+            "elementos": 4,
+            "caracteres": 66,
+            "palavras": 13,
+            "textos": [
+              "WHY LXL",
+              "WE’RE COLLABORATIVE",
+              "WE’RE UPFRONT & HONEST",
+              "WE LOVE WHAT WE DO"
+            ],
+            "fontFamily": "\"Owners Wide\", Impact, sans-serif",
+            "familiaEfetiva": "Owners Wide",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "owners wide",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "16.9074px",
+            "lineHeightRazao": 1.21,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 6,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "Manrope, Arial, sans-serif",
+          "familiaEfetiva": "Manrope",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "22.5253px",
+          "lineHeightRazao": 1.41,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 35
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            64,
+            33,
+            29,
+            21,
+            20,
+            14
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 26
+          },
+          "razao_semFiltro": 4,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 34,
+          "caracteresTotais": 1155,
+          "caracteresPor1000px": 86.74,
+          "semNeutralizar": 30,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Owners Wide\", Impact, sans-serif",
+            "contagem": 16
+          },
+          {
+            "familia": "Manrope, Arial, sans-serif",
+            "contagem": 9
+          },
+          {
+            "familia": "Scribo, Georgia, sans-serif",
+            "contagem": 2
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 64,
+          "tag": "h2",
+          "className": "feature-pills_heading u-text-style-display-accent",
+          "caracteres": 7,
+          "palavras": 2,
+          "fontFamily": "Scribo, Georgia, sans-serif",
+          "familiaEfetiva": "Scribo",
+          "familiaVerificada": true,
+          "serifa": true,
+          "fontWeight": "400",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 77.8
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            64,
+            33,
+            29,
+            21,
+            20,
+            14
+          ],
+          "maiorTexto": 64
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            64,
+            33,
+            29,
+            21,
+            20,
+            14
+          ],
+          "maiorTexto": 64
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            64,
+            33,
+            29,
+            21,
+            20,
+            14
+          ],
+          "maiorTexto": 64
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            64,
+            33,
+            29,
+            21,
+            20,
+            14
+          ],
+          "maiorTexto": 64
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            64,
+            33,
+            29,
+            21,
+            20,
+            14
+          ],
+          "maiorTexto": 64
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://lxlcreative.co.uk"
+    },
+    "lxlcreative@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:21:44.074Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 15406,
+        "imgs": 39,
+        "carregadas": 38
+      },
+      "data": {
+        "url": "https://www.lxlcreative.co.uk/",
+        "altura": 15406,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 6
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 15,
+        "telas_base900_legado": 17.1,
+        "metricaV2_hsvS015": 97.2,
+        "corPerceptivel_C005": 0.7,
+        "corForte_C012": 0.7,
+        "cromaMedioPonderado": 0.013,
+        "cromaPicoOklch": 0.251,
+        "fundos": [
+          {
+            "cor": "rgb(39,32,29)",
+            "pct": 96.5,
+            "L": 0.25,
+            "C": 0.012,
+            "H": 45
+          },
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 2.5,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          },
+          {
+            "cor": "rgb(5,93,255)",
+            "pct": 0.5,
+            "L": 0.55,
+            "C": 0.251,
+            "H": 262
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 0.3,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,81,33)",
+            "pct": 0.2,
+            "L": 0.67,
+            "C": 0.218,
+            "H": 35
+          },
+          {
+            "cor": "rgb(252,242,189)",
+            "pct": 0,
+            "L": 0.96,
+            "C": 0.069,
+            "H": 99
+          }
+        ],
+        "midia": {
+          "img": 39,
+          "svg": 54,
+          "video": 2,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 6.17,
+        "keyframes": 1,
+        "nomes": [
+          "spin"
+        ],
+        "keyframesPor1000": 0.06,
+        "folhasBloqueadas": 1,
+        "emTransicao": 83,
+        "emTransicaoPor1000": 5.39,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.5s",
+            23
+          ],
+          [
+            "0.3s",
+            18
+          ],
+          [
+            "0.15s",
+            14
+          ],
+          [
+            "0.2s",
+            13
+          ],
+          [
+            "0.25s",
+            6
+          ],
+          [
+            "0.35s",
+            5
+          ],
+          [
+            "0.6s",
+            4
+          ],
+          [
+            "0.4s",
+            4
+          ]
+        ],
+        "tamTitulos": [
+          80,
+          41,
+          34,
+          23,
+          21,
+          15
+        ],
+        "workhorse": {
+          "px": 17,
+          "ocorrencias": 12
+        },
+        "razaoTituloWorkhorse": 4.71,
+        "titulosDetalhes": [
+          {
+            "px": 80,
+            "elementos": 2,
+            "caracteres": 14,
+            "palavras": 3,
+            "textos": [
+              "Why lxl",
+              "Studios"
+            ],
+            "fontFamily": "Scribo, Georgia, sans-serif",
+            "familiaEfetiva": "Scribo",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "scribo",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "400",
+            "lineHeightPx": "72px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 41,
+            "elementos": 4,
+            "caracteres": 113,
+            "palavras": 18,
+            "textos": [
+              "REAL CRAFT.\n‍Real people.‍",
+              "REAL RESULTS.",
+              "Our SERVICES",
+              "GOT A PRODUCTION COMING UP? LET’S DO SOMETHING great TOGETHER."
+            ],
+            "fontFamily": "\"Owners Wide\", Impact, sans-serif",
+            "familiaEfetiva": "Owners Wide",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "owners wide",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "37.031px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 20,
+            "maiorLarguraCh": 20,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 34,
+            "elementos": 1,
+            "caracteres": 37,
+            "palavras": 6,
+            "textos": [
+              "WHERE BRANDS, MUSIC AND CULTURE MEET."
+            ],
+            "fontFamily": "\"Owners Wide\", Impact, sans-serif",
+            "familiaEfetiva": "Owners Wide",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "owners wide",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "33.7184px",
+            "lineHeightRazao": 0.99,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 10,
+            "maiorLarguraCh": 10,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 23,
+            "elementos": 1,
+            "caracteres": 39,
+            "palavras": 6,
+            "textos": [
+              "Discover some of our favourite projects"
+            ],
+            "fontFamily": "Manrope, Arial, sans-serif",
+            "familiaEfetiva": "Manrope",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "manrope",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "23.4272px",
+            "lineHeightRazao": 1.02,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 20,
+            "maiorLarguraCh": 20,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 21,
+            "elementos": 6,
+            "caracteres": 50,
+            "palavras": 8,
+            "textos": [
+              "ACTIVATIONS",
+              "EDITORIAL",
+              "EPK",
+              "UNIT",
+              "SOCIAL CAMPAIGNS",
+              "KEY ART"
+            ],
+            "fontFamily": "\"Owners Wide\", Impact, sans-serif",
+            "familiaEfetiva": "Owners Wide",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "owners wide",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "21.1456px",
+            "lineHeightRazao": 1.01,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 6,
+            "maiorLarguraCh": 6,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 15,
+            "elementos": 4,
+            "caracteres": 66,
+            "palavras": 13,
+            "textos": [
+              "WHY LXL",
+              "WE’RE COLLABORATIVE",
+              "WE’RE UPFRONT & HONEST",
+              "WE LOVE WHAT WE DO"
+            ],
+            "fontFamily": "\"Owners Wide\", Impact, sans-serif",
+            "familiaEfetiva": "Owners Wide",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "owners wide",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "17.4874px",
+            "lineHeightRazao": 1.17,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 6,
+            "maiorLarguraCh": 18,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 17,
+          "fontFamily": "Manrope, Arial, sans-serif",
+          "familiaEfetiva": "Manrope",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "23.2019px",
+          "lineHeightRazao": 1.36,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 34
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            80,
+            41,
+            34,
+            23,
+            21,
+            15
+          ],
+          "workhorse_semFiltro": {
+            "px": 17,
+            "ocorrencias": 26
+          },
+          "razao_semFiltro": 4.71,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 30,
+          "caracteresTotais": 1159,
+          "caracteresPor1000px": 75.23,
+          "semNeutralizar": 26,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Owners Wide\", Impact, sans-serif",
+            "contagem": 16
+          },
+          {
+            "familia": "Manrope, Arial, sans-serif",
+            "contagem": 14
+          },
+          {
+            "familia": "Scribo, Georgia, sans-serif",
+            "contagem": 2
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 80,
+          "tag": "h2",
+          "className": "feature-pills_heading u-text-style-display-accent",
+          "caracteres": 7,
+          "palavras": 2,
+          "fontFamily": "Scribo, Georgia, sans-serif",
+          "familiaEfetiva": "Scribo",
+          "familiaVerificada": true,
+          "serifa": true,
+          "fontWeight": "400",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 81.9
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            80,
+            41,
+            34,
+            23,
+            21,
+            15
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            80,
+            41,
+            34,
+            23,
+            21,
+            15
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            80,
+            41,
+            34,
+            23,
+            21,
+            15
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            80,
+            41,
+            34,
+            23,
+            21,
+            15
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            80,
+            41,
+            34,
+            23,
+            21,
+            15
+          ],
+          "maiorTexto": 80
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://lxlcreative.co.uk"
+    },
+    "white-desert@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:21:58.368Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 15304,
+        "imgs": 29,
+        "carregadas": 27
+      },
+      "data": {
+        "url": "https://white-desert.com/",
+        "altura": 15304,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 11
+        },
+        "viewportMedido": {
+          "w": 320,
+          "h": 568,
+          "dpr": 2
+        },
+        "telas": 26.9,
+        "telas_base900_legado": 17,
+        "metricaV2_hsvS015": 11.9,
+        "corPerceptivel_C005": 0.5,
+        "corForte_C012": 0.5,
+        "cromaMedioPonderado": 0.003,
+        "cromaPicoOklch": 0.185,
+        "fundos": [
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 74.7,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(9,11,16)",
+            "pct": 11.4,
+            "L": 0.15,
+            "C": 0.011,
+            "H": 268
+          },
+          {
+            "cor": "rgb(233,231,225)",
+            "pct": 9.5,
+            "L": 0.93,
+            "C": 0.008,
+            "H": 91
+          },
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 2.2,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          },
+          {
+            "cor": "rgb(240,240,240)",
+            "pct": 0.9,
+            "L": 0.96,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(243,241,236)",
+            "pct": 0.9,
+            "L": 0.96,
+            "C": 0.007,
+            "H": 89
+          }
+        ],
+        "midia": {
+          "img": 29,
+          "svg": 56,
+          "video": 1,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 5.62,
+        "keyframes": 6,
+        "nomes": [
+          "page-exit",
+          "page-enter",
+          "reveal-opacity",
+          "reveal-transform",
+          "fadeIn",
+          "pulsed"
+        ],
+        "keyframesPor1000": 0.39,
+        "folhasBloqueadas": 0,
+        "emTransicao": 126,
+        "emTransicaoPor1000": 8.23,
+        "animacoesAtivas": 4,
+        "duracoes": [
+          [
+            "0.3s",
+            115
+          ],
+          [
+            "0.6s",
+            5
+          ],
+          [
+            "0.45s",
+            4
+          ],
+          [
+            "0.4s",
+            1
+          ],
+          [
+            "1s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          200,
+          80,
+          60,
+          42,
+          32,
+          26
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 37
+        },
+        "razaoTituloWorkhorse": 12.5,
+        "titulosDetalhes": [
+          {
+            "px": 200,
+            "elementos": 1,
+            "caracteres": 7,
+            "palavras": 2,
+            "textos": [
+              "CPT\nWFR"
+            ],
+            "fontFamily": "Oswald, \"Arial Narrow\", Arial, sans-serif",
+            "familiaEfetiva": "Oswald",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "oswald",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "180px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 3,
+            "maiorLarguraCh": 3,
+            "fracaoContidaMin": 0.98,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 80,
+            "elementos": 1,
+            "caracteres": 10,
+            "palavras": 1,
+            "textos": [
+              "ANTARCTICA"
+            ],
+            "fontFamily": "Oswald, \"Arial Narrow\", Arial, sans-serif",
+            "familiaEfetiva": "Oswald",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "oswald",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "80px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 0.87,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 60,
+            "elementos": 1,
+            "caracteres": 9,
+            "palavras": 2,
+            "textos": [
+              "OUR CAMPS"
+            ],
+            "fontFamily": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "familiaEfetiva": "Cardinal Classic Long",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cardinal classic long",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "normal",
+            "lineHeightRazao": 1.33,
+            "lineHeightOrigem": "normal-medida",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "1/5"
+          },
+          {
+            "px": 42,
+            "elementos": 5,
+            "caracteres": 105,
+            "palavras": 21,
+            "textos": [
+              "Baby Penguins & Blue Tunnels",
+              "South Pole & Penguins",
+              "South Pole & Blue Rivers",
+              "The Long Stay",
+              "Antarctica in a Day"
+            ],
+            "fontFamily": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "familiaEfetiva": "ui-serif",
+            "familiaVerificada": true,
+            "caiuParaFallback": true,
+            "familiaDeclarada": "cardinal classic long",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "42px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 10,
+            "maiorLarguraCh": 10,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 32,
+            "elementos": 4,
+            "caracteres": 49,
+            "palavras": 13,
+            "textos": [
+              "OUR TRIPS",
+              "05:30 HRS",
+              "4,220 KM / 2,610 MI",
+              "-5°C / 23° F"
+            ],
+            "fontFamily": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "familiaEfetiva": "Cardinal Classic Long",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cardinal classic long",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "32px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 10,
+            "maiorLarguraCh": 13,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 26,
+            "elementos": 6,
+            "caracteres": 206,
+            "palavras": 31,
+            "textos": [
+              "VAST, MAJESTIC AND UNIMAGINABLY BEAUTIFUL — SETTING FOOT IN ANTARCTICA’S FABLED INTERIOR REMAINS A RARE AND EXTRAORDINAR",
+              "WHICHAWAY",
+              "ECHO",
+              "EXPLORER",
+              "TO THE END OF THE EARTH",
+              "START PLANNING YOUR ADVENTURE"
+            ],
+            "fontFamily": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "familiaEfetiva": "Cardinal Classic Long",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cardinal classic long",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "26px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 16,
+            "maiorLarguraCh": 16,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"Inter Tight\", ui-sans-serif, system-ui, -apple-system, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\"",
+          "familiaEfetiva": "Inter Tight",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "22.4px",
+          "lineHeightRazao": 1.4,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 26
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            200,
+            80,
+            60,
+            42,
+            32,
+            26,
+            18
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 42
+          },
+          "razao_semFiltro": 12.5,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 18,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "1. Consultation"
+            },
+            {
+              "px": 18,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "2. Confirmation"
+            },
+            {
+              "px": 18,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "3. Planning"
+            },
+            {
+              "px": 18,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "4. On-Boarding"
+            },
+            {
+              "px": 18,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "5. Safety Briefing"
+            },
+            {
+              "px": 18,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "6. Departure"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 24,
+          "caracteresTotais": 494,
+          "caracteresPor1000px": 32.28,
+          "semNeutralizar": 24,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Inter Tight\", ui-sans-serif, system-ui, -apple-system, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\"",
+            "contagem": 54
+          },
+          {
+            "familia": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "contagem": 30
+          },
+          {
+            "familia": "Oswald, \"Arial Narrow\", Arial, sans-serif",
+            "contagem": 10
+          },
+          {
+            "familia": "\"Cardinal Classic Long\", serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 200,
+          "tag": "h2",
+          "className": "title-fade",
+          "caracteres": 6,
+          "palavras": 1,
+          "fontFamily": "Oswald, \"Arial Narrow\", Arial, sans-serif",
+          "familiaEfetiva": "Oswald",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "400",
+          "textTransform": "uppercase",
+          "fracaoContida": 0.98,
+          "profundidadeDeRolagem": 67
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": true
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            200,
+            80,
+            42,
+            32,
+            26
+          ],
+          "maiorTexto": 200
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            200,
+            80,
+            42,
+            32,
+            26
+          ],
+          "maiorTexto": 200
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            200,
+            80,
+            42,
+            32,
+            26
+          ],
+          "maiorTexto": 200
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            200,
+            80,
+            42,
+            32,
+            26
+          ],
+          "maiorTexto": 200
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            200,
+            80,
+            60,
+            42,
+            32,
+            26
+          ],
+          "maiorTexto": 200
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://white-desert.com"
+    },
+    "white-desert@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:22:12.005Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 19265,
+        "imgs": 29,
+        "carregadas": 27
+      },
+      "data": {
+        "url": "https://white-desert.com/",
+        "altura": 19265,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 11
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 22.8,
+        "telas_base900_legado": 21.4,
+        "metricaV2_hsvS015": 11.2,
+        "corPerceptivel_C005": 0.4,
+        "corForte_C012": 0.4,
+        "cromaMedioPonderado": 0.003,
+        "cromaPicoOklch": 0.185,
+        "fundos": [
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 76.9,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(9,11,16)",
+            "pct": 10.8,
+            "L": 0.15,
+            "C": 0.011,
+            "H": 268
+          },
+          {
+            "cor": "rgb(233,231,225)",
+            "pct": 7.7,
+            "L": 0.93,
+            "C": 0.008,
+            "H": 91
+          },
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 2.7,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          },
+          {
+            "cor": "rgb(240,240,240)",
+            "pct": 0.9,
+            "L": 0.96,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(243,241,236)",
+            "pct": 0.7,
+            "L": 0.96,
+            "C": 0.007,
+            "H": 89
+          }
+        ],
+        "midia": {
+          "img": 29,
+          "svg": 56,
+          "video": 1,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 4.46,
+        "keyframes": 6,
+        "nomes": [
+          "page-exit",
+          "page-enter",
+          "reveal-opacity",
+          "reveal-transform",
+          "fadeIn",
+          "pulsed"
+        ],
+        "keyframesPor1000": 0.31,
+        "folhasBloqueadas": 0,
+        "emTransicao": 126,
+        "emTransicaoPor1000": 6.54,
+        "animacoesAtivas": 4,
+        "duracoes": [
+          [
+            "0.3s",
+            115
+          ],
+          [
+            "0.6s",
+            5
+          ],
+          [
+            "0.45s",
+            4
+          ],
+          [
+            "0.4s",
+            1
+          ],
+          [
+            "1s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          200,
+          80,
+          60,
+          42,
+          32,
+          26
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 37
+        },
+        "razaoTituloWorkhorse": 12.5,
+        "titulosDetalhes": [
+          {
+            "px": 200,
+            "elementos": 1,
+            "caracteres": 7,
+            "palavras": 2,
+            "textos": [
+              "CPT\nWFR"
+            ],
+            "fontFamily": "Oswald, \"Arial Narrow\", Arial, sans-serif",
+            "familiaEfetiva": "Oswald",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "oswald",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "180px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 3,
+            "maiorLarguraCh": 3,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 80,
+            "elementos": 1,
+            "caracteres": 10,
+            "palavras": 1,
+            "textos": [
+              "ANTARCTICA"
+            ],
+            "fontFamily": "Oswald, \"Arial Narrow\", Arial, sans-serif",
+            "familiaEfetiva": "Oswald",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "oswald",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "80px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 60,
+            "elementos": 1,
+            "caracteres": 9,
+            "palavras": 2,
+            "textos": [
+              "OUR CAMPS"
+            ],
+            "fontFamily": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "familiaEfetiva": "Cardinal Classic Long",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cardinal classic long",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "normal",
+            "lineHeightRazao": 1.33,
+            "lineHeightOrigem": "normal-medida",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 10,
+            "maiorLarguraCh": 10,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "1/5"
+          },
+          {
+            "px": 42,
+            "elementos": 5,
+            "caracteres": 105,
+            "palavras": 21,
+            "textos": [
+              "Baby Penguins & Blue Tunnels",
+              "South Pole & Penguins",
+              "South Pole & Blue Rivers",
+              "The Long Stay",
+              "Antarctica in a Day"
+            ],
+            "fontFamily": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "familiaEfetiva": "ui-serif",
+            "familiaVerificada": true,
+            "caiuParaFallback": true,
+            "familiaDeclarada": "cardinal classic long",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "42px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 12,
+            "maiorLarguraCh": 12,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 32,
+            "elementos": 4,
+            "caracteres": 49,
+            "palavras": 13,
+            "textos": [
+              "OUR TRIPS",
+              "05:30 HRS",
+              "4,220 KM / 2,610 MI",
+              "-5°C / 23° F"
+            ],
+            "fontFamily": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "familiaEfetiva": "Cardinal Classic Long",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cardinal classic long",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "32px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 14,
+            "maiorLarguraCh": 17,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 26,
+            "elementos": 6,
+            "caracteres": 206,
+            "palavras": 31,
+            "textos": [
+              "VAST, MAJESTIC AND UNIMAGINABLY BEAUTIFUL — SETTING FOOT IN ANTARCTICA’S FABLED INTERIOR REMAINS A RARE AND EXTRAORDINAR",
+              "WHICHAWAY",
+              "ECHO",
+              "EXPLORER",
+              "TO THE END OF THE EARTH",
+              "START PLANNING YOUR ADVENTURE"
+            ],
+            "fontFamily": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "familiaEfetiva": "Cardinal Classic Long",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cardinal classic long",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "26px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 20,
+            "maiorLarguraCh": 20,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"Inter Tight\", ui-sans-serif, system-ui, -apple-system, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\"",
+          "familiaEfetiva": "Inter Tight",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "22.4px",
+          "lineHeightRazao": 1.4,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 34
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            200,
+            80,
+            60,
+            42,
+            32,
+            26,
+            18
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 42
+          },
+          "razao_semFiltro": 12.5,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 18,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "1. Consultation"
+            },
+            {
+              "px": 18,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "2. Confirmation"
+            },
+            {
+              "px": 18,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "3. Planning"
+            },
+            {
+              "px": 18,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "4. On-Boarding"
+            },
+            {
+              "px": 18,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "5. Safety Briefing"
+            },
+            {
+              "px": 18,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "6. Departure"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 24,
+          "caracteresTotais": 494,
+          "caracteresPor1000px": 25.64,
+          "semNeutralizar": 24,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Inter Tight\", ui-sans-serif, system-ui, -apple-system, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\"",
+            "contagem": 54
+          },
+          {
+            "familia": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "contagem": 30
+          },
+          {
+            "familia": "Oswald, \"Arial Narrow\", Arial, sans-serif",
+            "contagem": 10
+          },
+          {
+            "familia": "\"Cardinal Classic Long\", serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 200,
+          "tag": "h2",
+          "className": "title-fade",
+          "caracteres": 6,
+          "palavras": 1,
+          "fontFamily": "Oswald, \"Arial Narrow\", Arial, sans-serif",
+          "familiaEfetiva": "Oswald",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "400",
+          "textTransform": "uppercase",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 70.8
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": true
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            200,
+            80,
+            42,
+            32,
+            26
+          ],
+          "maiorTexto": 200
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            200,
+            80,
+            42,
+            32,
+            26
+          ],
+          "maiorTexto": 200
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            200,
+            80,
+            42,
+            32,
+            26
+          ],
+          "maiorTexto": 200
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            200,
+            80,
+            42,
+            32,
+            26
+          ],
+          "maiorTexto": 200
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            200,
+            80,
+            60,
+            42,
+            32,
+            26
+          ],
+          "maiorTexto": 200
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://white-desert.com"
+    },
+    "white-desert@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:22:25.821Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 20085,
+        "imgs": 29,
+        "carregadas": 27
+      },
+      "data": {
+        "url": "https://white-desert.com/",
+        "altura": 20085,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 11
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 19.6,
+        "telas_base900_legado": 22.3,
+        "metricaV2_hsvS015": 13.8,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0.002,
+        "cromaPicoOklch": 0.185,
+        "fundos": [
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 76.4,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(9,11,16)",
+            "pct": 13.7,
+            "L": 0.15,
+            "C": 0.011,
+            "H": 268
+          },
+          {
+            "cor": "rgb(233,231,225)",
+            "pct": 3.2,
+            "L": 0.93,
+            "C": 0.008,
+            "H": 91
+          },
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 2.9,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          },
+          {
+            "cor": "rgb(245,245,245)",
+            "pct": 2,
+            "L": 0.97,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(240,240,240)",
+            "pct": 1.2,
+            "L": 0.96,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 29,
+          "svg": 56,
+          "video": 1,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 4.28,
+        "keyframes": 6,
+        "nomes": [
+          "page-exit",
+          "page-enter",
+          "reveal-opacity",
+          "reveal-transform",
+          "fadeIn",
+          "pulsed"
+        ],
+        "keyframesPor1000": 0.3,
+        "folhasBloqueadas": 0,
+        "emTransicao": 147,
+        "emTransicaoPor1000": 7.32,
+        "animacoesAtivas": 4,
+        "duracoes": [
+          [
+            "0.3s",
+            136
+          ],
+          [
+            "0.6s",
+            5
+          ],
+          [
+            "0.45s",
+            4
+          ],
+          [
+            "0.4s",
+            1
+          ],
+          [
+            "1s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          320,
+          256,
+          140,
+          90,
+          60,
+          42,
+          32,
+          18
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 38
+        },
+        "razaoTituloWorkhorse": 20,
+        "titulosDetalhes": [
+          {
+            "px": 320,
+            "elementos": 1,
+            "caracteres": 9,
+            "palavras": 3,
+            "textos": [
+              "CPT – WFR"
+            ],
+            "fontFamily": "Oswald, \"Arial Narrow\", Arial, sans-serif",
+            "familiaEfetiva": "Oswald",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "oswald",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "288px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 4,
+            "maiorLarguraCh": 4,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 256,
+            "elementos": 1,
+            "caracteres": 10,
+            "palavras": 1,
+            "textos": [
+              "ANTARCTICA"
+            ],
+            "fontFamily": "Oswald, \"Arial Narrow\", Arial, sans-serif",
+            "familiaEfetiva": "Oswald",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "oswald",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "256px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 5,
+            "maiorLarguraCh": 5,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 140,
+            "elementos": 1,
+            "caracteres": 9,
+            "palavras": 2,
+            "textos": [
+              "OUR CAMPS"
+            ],
+            "fontFamily": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "familiaEfetiva": "Cardinal Classic Long",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cardinal classic long",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "normal",
+            "lineHeightRazao": 1.34,
+            "lineHeightOrigem": "normal-medida",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "1/5"
+          },
+          {
+            "px": 90,
+            "elementos": 1,
+            "caracteres": 9,
+            "palavras": 2,
+            "textos": [
+              "OUR CAMPS"
+            ],
+            "fontFamily": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "familiaEfetiva": "Cardinal Classic Long",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cardinal classic long",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "normal",
+            "lineHeightRazao": 1.34,
+            "lineHeightOrigem": "normal-medida",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 10,
+            "maiorLarguraCh": 10,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "4/5"
+          },
+          {
+            "px": 60,
+            "elementos": 1,
+            "caracteres": 9,
+            "palavras": 2,
+            "textos": [
+              "OUR TRIPS"
+            ],
+            "fontFamily": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "familiaEfetiva": "Cardinal Classic Long",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cardinal classic long",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "60px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 42,
+            "elementos": 7,
+            "caracteres": 234,
+            "palavras": 36,
+            "textos": [
+              "VAST, MAJESTIC AND UNIMAGINABLY BEAUTIFUL — SETTING FOOT IN ANTARCTICA’S FABLED INTERIOR REMAINS A RARE AND EXTRAORDINAR",
+              "Baby Penguins & Blue Tunnels",
+              "WHICHAWAY",
+              "ECHO",
+              "EXPLORER",
+              "TO THE END OF THE EARTH"
+            ],
+            "fontFamily": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "familiaEfetiva": "Cardinal Classic Long",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cardinal classic long",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "42px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 15,
+            "maiorLarguraCh": 26,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 32,
+            "elementos": 4,
+            "caracteres": 52,
+            "palavras": 14,
+            "textos": [
+              "05:30 HRS",
+              "4,220 KM / 2,610 MI",
+              "-5°C / 23° F",
+              "HOW IT WORKS"
+            ],
+            "fontFamily": "\"Inter Tight\", ui-sans-serif, system-ui, -apple-system, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\"",
+            "familiaEfetiva": "Inter Tight",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter tight",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "48px",
+            "lineHeightRazao": 1.5,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 37,
+            "maiorLarguraCh": 37,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 6,
+            "caracteres": 85,
+            "palavras": 13,
+            "textos": [
+              "1. Consultation",
+              "2. Confirmation",
+              "3. Planning",
+              "4. On-Boarding",
+              "5. Safety Briefing",
+              "6. Departure"
+            ],
+            "fontFamily": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "familiaEfetiva": "ui-serif",
+            "familiaVerificada": true,
+            "caiuParaFallback": true,
+            "familiaDeclarada": "cardinal classic long",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "21.6px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 9,
+            "maiorLarguraCh": 10,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"Inter Tight\", ui-sans-serif, system-ui, -apple-system, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\"",
+          "familiaEfetiva": "Inter Tight",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "normal",
+          "lineHeightRazao": 1.25,
+          "lineHeightOrigem": "normal-medida",
+          "largura_ch": 22
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            320,
+            256,
+            140,
+            60,
+            42,
+            32,
+            18
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 42
+          },
+          "razao_semFiltro": 20,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 25,
+          "caracteresTotais": 509,
+          "caracteresPor1000px": 25.34,
+          "semNeutralizar": 25,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Inter Tight\", ui-sans-serif, system-ui, -apple-system, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, \"Noto Sans\", \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\"",
+            "contagem": 61
+          },
+          {
+            "familia": "\"Cardinal Classic Long\", ui-serif, Georgia, Cambria, \"Times New Roman\", Times, serif",
+            "contagem": 33
+          },
+          {
+            "familia": "Oswald, \"Arial Narrow\", Arial, sans-serif",
+            "contagem": 10
+          },
+          {
+            "familia": "\"Cardinal Classic Long\", serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 320,
+          "tag": "h2",
+          "className": "title-fade",
+          "caracteres": 9,
+          "palavras": 3,
+          "fontFamily": "Oswald, \"Arial Narrow\", Arial, sans-serif",
+          "familiaEfetiva": "Oswald",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "400",
+          "textTransform": "uppercase",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 72.6
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": true
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            320,
+            256,
+            90,
+            60,
+            42,
+            32,
+            18
+          ],
+          "maiorTexto": 320
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            320,
+            256,
+            90,
+            60,
+            42,
+            32,
+            18
+          ],
+          "maiorTexto": 320
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            320,
+            256,
+            90,
+            60,
+            42,
+            32,
+            18
+          ],
+          "maiorTexto": 320
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            320,
+            256,
+            90,
+            60,
+            42,
+            32,
+            18
+          ],
+          "maiorTexto": 320
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            320,
+            256,
+            140,
+            60,
+            42,
+            32,
+            18
+          ],
+          "maiorTexto": 320
+        }
+      ],
+      "rotulo": "aprovado",
+      "url": "https://white-desert.com"
+    },
+    "charityshot@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:22:36.131Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 1344,
+        "imgs": 73,
+        "carregadas": 15
+      },
+      "data": {
+        "url": "https://charityshot.co.uk/",
+        "altura": 1344,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 320,
+          "h": 568,
+          "dpr": 2
+        },
+        "telas": 2.4,
+        "telas_base900_legado": 1.5,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(252,252,252)",
+            "pct": 52,
+            "L": 0.99,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 47,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 1,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          }
+        ],
+        "midia": {
+          "img": 73,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 54.32,
+        "keyframes": 6,
+        "nomes": [
+          "search-slide-in",
+          "develop-print",
+          "v-down",
+          "v-up",
+          "h-left",
+          "h-right"
+        ],
+        "keyframesPor1000": 4.46,
+        "folhasBloqueadas": 0,
+        "emTransicao": 81,
+        "emTransicaoPor1000": 60.27,
+        "animacoesAtivas": 4,
+        "duracoes": [
+          [
+            "0.3s",
+            75
+          ],
+          [
+            "0.15s",
+            6
+          ]
+        ],
+        "tamTitulos": [
+          28
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 1
+        },
+        "razaoTituloWorkhorse": 1.75,
+        "titulosDetalhes": [
+          {
+            "px": 28,
+            "elementos": 1,
+            "caracteres": 12,
+            "palavras": 2,
+            "textos": [
+              "CHARITY SHOT"
+            ],
+            "fontFamily": "\"Courier New\", Courier, monospace",
+            "familiaEfetiva": "Courier New",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "courier new",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "800",
+            "lineHeightPx": "26.6px",
+            "lineHeightRazao": 0.95,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.56px",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 14,
+            "maiorLarguraCh": 14,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"Courier New\", Courier, monospace",
+          "familiaEfetiva": "Courier New",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "25.6px",
+          "lineHeightRazao": 1.6,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 24
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            28
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 1
+          },
+          "razao_semFiltro": 1.75,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 9,
+          "caracteresTotais": 64,
+          "caracteresPor1000px": 47.62,
+          "semNeutralizar": 9,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Courier New\", Courier, monospace",
+            "contagem": 2
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 28,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 12,
+          "palavras": 2,
+          "fontFamily": "\"Courier New\", Courier, monospace",
+          "familiaEfetiva": "Courier New",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "800",
+          "textTransform": "uppercase",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 11.6
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://charityshot.co.uk"
+    },
+    "charityshot@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:22:46.424Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 1650,
+        "imgs": 73,
+        "carregadas": 12
+      },
+      "data": {
+        "url": "https://charityshot.co.uk/",
+        "altura": 1650,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 2,
+        "telas_base900_legado": 1.8,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(252,252,252)",
+            "pct": 51.7,
+            "L": 0.99,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 47.6,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 0.7,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          }
+        ],
+        "midia": {
+          "img": 73,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 44.24,
+        "keyframes": 6,
+        "nomes": [
+          "search-slide-in",
+          "develop-print",
+          "v-down",
+          "v-up",
+          "h-left",
+          "h-right"
+        ],
+        "keyframesPor1000": 3.64,
+        "folhasBloqueadas": 0,
+        "emTransicao": 81,
+        "emTransicaoPor1000": 49.09,
+        "animacoesAtivas": 4,
+        "duracoes": [
+          [
+            "0.3s",
+            75
+          ],
+          [
+            "0.15s",
+            6
+          ]
+        ],
+        "tamTitulos": [
+          28
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 1
+        },
+        "razaoTituloWorkhorse": 1.75,
+        "titulosDetalhes": [
+          {
+            "px": 28,
+            "elementos": 1,
+            "caracteres": 12,
+            "palavras": 2,
+            "textos": [
+              "CHARITY SHOT"
+            ],
+            "fontFamily": "\"Courier New\", Courier, monospace",
+            "familiaEfetiva": "Courier New",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "courier new",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "800",
+            "lineHeightPx": "26.6px",
+            "lineHeightRazao": 0.95,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.56px",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 19,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"Courier New\", Courier, monospace",
+          "familiaEfetiva": "Courier New",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "25.6px",
+          "lineHeightRazao": 1.6,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 31
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            28
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 1
+          },
+          "razao_semFiltro": 1.75,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 9,
+          "caracteresTotais": 64,
+          "caracteresPor1000px": 38.79,
+          "semNeutralizar": 9,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Courier New\", Courier, monospace",
+            "contagem": 2
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 28,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 12,
+          "palavras": 2,
+          "fontFamily": "\"Courier New\", Courier, monospace",
+          "familiaEfetiva": "Courier New",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "800",
+          "textTransform": "uppercase",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 9.5
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://charityshot.co.uk"
+    },
+    "charityshot@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:22:56.565Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 1789,
+        "imgs": 73,
+        "carregadas": 15
+      },
+      "data": {
+        "url": "https://charityshot.co.uk/",
+        "altura": 1789,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 1.7,
+        "telas_base900_legado": 2,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(252,252,252)",
+            "pct": 51.2,
+            "L": 0.99,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 48.5,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 0.3,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          }
+        ],
+        "midia": {
+          "img": 73,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 40.8,
+        "keyframes": 6,
+        "nomes": [
+          "search-slide-in",
+          "develop-print",
+          "v-down",
+          "v-up",
+          "h-left",
+          "h-right"
+        ],
+        "keyframesPor1000": 3.35,
+        "folhasBloqueadas": 0,
+        "emTransicao": 81,
+        "emTransicaoPor1000": 45.28,
+        "animacoesAtivas": 4,
+        "duracoes": [
+          [
+            "0.3s",
+            75
+          ],
+          [
+            "0.15s",
+            6
+          ]
+        ],
+        "tamTitulos": [
+          28
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 1
+        },
+        "razaoTituloWorkhorse": 1.75,
+        "titulosDetalhes": [
+          {
+            "px": 28,
+            "elementos": 1,
+            "caracteres": 12,
+            "palavras": 2,
+            "textos": [
+              "CHARITY SHOT"
+            ],
+            "fontFamily": "\"Courier New\", Courier, monospace",
+            "familiaEfetiva": "Courier New",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "courier new",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "800",
+            "lineHeightPx": "26.6px",
+            "lineHeightRazao": 0.95,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.56px",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 42,
+            "maiorLarguraCh": 42,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"Courier New\", Courier, monospace",
+          "familiaEfetiva": "Courier New",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "25.6px",
+          "lineHeightRazao": 1.6,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 71
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            28
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 1
+          },
+          "razao_semFiltro": 1.75,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 9,
+          "caracteresTotais": 64,
+          "caracteresPor1000px": 35.77,
+          "semNeutralizar": 9,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Courier New\", Courier, monospace",
+            "contagem": 2
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 28,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 12,
+          "palavras": 2,
+          "fontFamily": "\"Courier New\", Courier, monospace",
+          "familiaEfetiva": "Courier New",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "800",
+          "textTransform": "uppercase",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 8.7
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            28
+          ],
+          "maiorTexto": 28
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://charityshot.co.uk"
+    },
+    "obspogon@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:23:12.881Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 4821,
+        "imgs": 33,
+        "carregadas": 30
+      },
+      "data": {
+        "url": "https://obspogon.neocities.org/",
+        "altura": 4821,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 24
+        },
+        "viewportMedido": {
+          "w": 320,
+          "h": 568,
+          "dpr": 2
+        },
+        "telas": 8.5,
+        "telas_base900_legado": 5.4,
+        "metricaV2_hsvS015": 3.2,
+        "corPerceptivel_C005": 3.2,
+        "corForte_C012": 1.4,
+        "cromaMedioPonderado": 0.005,
+        "cromaPicoOklch": 0.177,
+        "fundos": [
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 95.5,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          },
+          {
+            "cor": "rgb(121,190,242)",
+            "pct": 1.5,
+            "L": 0.78,
+            "C": 0.102,
+            "H": 242
+          },
+          {
+            "cor": "rgb(0,128,0)",
+            "pct": 1.4,
+            "L": 0.52,
+            "C": 0.177,
+            "H": 142
+          },
+          {
+            "cor": "rgb(255,252,223)",
+            "pct": 1.3,
+            "L": 0.99,
+            "C": 0.038,
+            "H": 102
+          },
+          {
+            "cor": "rgb(189,105,91)",
+            "pct": 0.3,
+            "L": 0.61,
+            "C": 0.11,
+            "H": 31
+          }
+        ],
+        "midia": {
+          "img": 33,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 6.85,
+        "keyframes": 7,
+        "nomes": [
+          "fa-beat",
+          "fa-bounce",
+          "fa-fade",
+          "fa-beat-fade",
+          "fa-flip",
+          "fa-shake",
+          "fa-spin"
+        ],
+        "keyframesPor1000": 1.45,
+        "folhasBloqueadas": 1,
+        "emTransicao": 72,
+        "emTransicaoPor1000": 14.93,
+        "animacoesAtivas": 2,
+        "duracoes": [
+          [
+            "0.2s",
+            72
+          ]
+        ],
+        "tamTitulos": [
+          32
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 16
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 32,
+            "elementos": 1,
+            "caracteres": 15,
+            "palavras": 2,
+            "textos": [
+              "Obspogon's Zone"
+            ],
+            "fontFamily": "Verdana, sans-serif",
+            "familiaEfetiva": "Verdana",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "verdana",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "48px",
+            "lineHeightRazao": 1.5,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 12,
+            "maiorLarguraCh": 12,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "Verdana, sans-serif",
+          "familiaEfetiva": "Verdana",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "24px",
+          "lineHeightRazao": 1.5,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 28
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            32
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 16
+          },
+          "razao_semFiltro": 2,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Verdana, sans-serif",
+            "contagem": 18
+          },
+          {
+            "familia": "monospace",
+            "contagem": 1
+          },
+          {
+            "familia": "\"Open Sans\", sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 32,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 15,
+          "palavras": 2,
+          "fontFamily": "Verdana, sans-serif",
+          "familiaEfetiva": "Verdana",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 1.5
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://obspogon.neocities.org"
+    },
+    "obspogon@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:23:25.756Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 4579,
+        "imgs": 33,
+        "carregadas": 30
+      },
+      "data": {
+        "url": "https://obspogon.neocities.org/",
+        "altura": 4579,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 24
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 5.4,
+        "telas_base900_legado": 5.1,
+        "metricaV2_hsvS015": 2.6,
+        "corPerceptivel_C005": 2.6,
+        "corForte_C012": 1.2,
+        "cromaMedioPonderado": 0.004,
+        "cromaPicoOklch": 0.177,
+        "fundos": [
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 97.4,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          },
+          {
+            "cor": "rgb(121,190,242)",
+            "pct": 1.4,
+            "L": 0.78,
+            "C": 0.102,
+            "H": 242
+          },
+          {
+            "cor": "rgb(0,128,0)",
+            "pct": 1.2,
+            "L": 0.52,
+            "C": 0.177,
+            "H": 142
+          }
+        ],
+        "midia": {
+          "img": 33,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 7.21,
+        "keyframes": 7,
+        "nomes": [
+          "fa-beat",
+          "fa-bounce",
+          "fa-fade",
+          "fa-beat-fade",
+          "fa-flip",
+          "fa-shake",
+          "fa-spin"
+        ],
+        "keyframesPor1000": 1.53,
+        "folhasBloqueadas": 1,
+        "emTransicao": 70,
+        "emTransicaoPor1000": 15.29,
+        "animacoesAtivas": 2,
+        "duracoes": [
+          [
+            "0.2s",
+            70
+          ]
+        ],
+        "tamTitulos": [
+          32
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 16
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 32,
+            "elementos": 1,
+            "caracteres": 15,
+            "palavras": 2,
+            "textos": [
+              "Obspogon's Zone"
+            ],
+            "fontFamily": "Verdana, sans-serif",
+            "familiaEfetiva": "Verdana",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "verdana",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "48px",
+            "lineHeightRazao": 1.5,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 16,
+            "maiorLarguraCh": 16,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "Verdana, sans-serif",
+          "familiaEfetiva": "Verdana",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "24px",
+          "lineHeightRazao": 1.5,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 35
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            32
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 16
+          },
+          "razao_semFiltro": 2,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Verdana, sans-serif",
+            "contagem": 18
+          },
+          {
+            "familia": "monospace",
+            "contagem": 1
+          },
+          {
+            "familia": "\"Open Sans\", sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 32,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 15,
+          "palavras": 2,
+          "fontFamily": "Verdana, sans-serif",
+          "familiaEfetiva": "Verdana",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 1.6
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://obspogon.neocities.org"
+    },
+    "obspogon@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:23:39.342Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 3526,
+        "imgs": 33,
+        "carregadas": 31
+      },
+      "data": {
+        "url": "https://obspogon.neocities.org/",
+        "altura": 3526,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 24
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 3.4,
+        "telas_base900_legado": 3.9,
+        "metricaV2_hsvS015": 1.7,
+        "corPerceptivel_C005": 1.7,
+        "corForte_C012": 0.8,
+        "cromaMedioPonderado": 0.002,
+        "cromaPicoOklch": 0.177,
+        "fundos": [
+          {
+            "cor": "rgb(0,0,0)",
+            "pct": 98.3,
+            "L": 0,
+            "C": 0,
+            "H": 0
+          },
+          {
+            "cor": "rgb(121,190,242)",
+            "pct": 0.9,
+            "L": 0.78,
+            "C": 0.102,
+            "H": 242
+          },
+          {
+            "cor": "rgb(0,128,0)",
+            "pct": 0.8,
+            "L": 0.52,
+            "C": 0.177,
+            "H": 142
+          }
+        ],
+        "midia": {
+          "img": 33,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 9.36,
+        "keyframes": 7,
+        "nomes": [
+          "fa-beat",
+          "fa-bounce",
+          "fa-fade",
+          "fa-beat-fade",
+          "fa-flip",
+          "fa-shake",
+          "fa-spin"
+        ],
+        "keyframesPor1000": 1.99,
+        "folhasBloqueadas": 1,
+        "emTransicao": 70,
+        "emTransicaoPor1000": 19.85,
+        "animacoesAtivas": 2,
+        "duracoes": [
+          [
+            "0.2s",
+            70
+          ]
+        ],
+        "tamTitulos": [
+          32
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 16
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 32,
+            "elementos": 1,
+            "caracteres": 15,
+            "palavras": 2,
+            "textos": [
+              "Obspogon's Zone"
+            ],
+            "fontFamily": "Verdana, sans-serif",
+            "familiaEfetiva": "Verdana",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "verdana",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "48px",
+            "lineHeightRazao": 1.5,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 32,
+            "maiorLarguraCh": 32,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "Verdana, sans-serif",
+          "familiaEfetiva": "Verdana",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "24px",
+          "lineHeightRazao": 1.5,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 72
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            32
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 16
+          },
+          "razao_semFiltro": 2,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Verdana, sans-serif",
+            "contagem": 18
+          },
+          {
+            "familia": "monospace",
+            "contagem": 1
+          },
+          {
+            "familia": "\"Open Sans\", sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 32,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 15,
+          "palavras": 2,
+          "fontFamily": "Verdana, sans-serif",
+          "familiaEfetiva": "Verdana",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 2
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://obspogon.neocities.org"
+    },
+    "paulfragara@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:23:50.078Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 4936,
+        "imgs": 14,
+        "carregadas": 14
+      },
+      "data": {
+        "url": "https://paul.fragara.com/",
+        "altura": 4936,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 320,
+          "h": 568,
+          "dpr": 2
+        },
+        "telas": 8.7,
+        "telas_base900_legado": 5.5,
+        "metricaV2_hsvS015": 0.9,
+        "corPerceptivel_C005": 0.9,
+        "corForte_C012": 0.9,
+        "cromaMedioPonderado": 0.015,
+        "cromaPicoOklch": 0.194,
+        "fundos": [
+          {
+            "cor": "rgb(240,255,240)",
+            "pct": 53,
+            "L": 0.98,
+            "C": 0.025,
+            "H": 145
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 45.4,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(248,233,0)",
+            "pct": 0.6,
+            "L": 0.92,
+            "C": 0.194,
+            "H": 105
+          },
+          {
+            "cor": "rgb(102,102,102)",
+            "pct": 0.5,
+            "L": 0.51,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(0,119,0)",
+            "pct": 0.3,
+            "L": 0.49,
+            "C": 0.168,
+            "H": 142
+          },
+          {
+            "cor": "rgb(227,232,227)",
+            "pct": 0.2,
+            "L": 0.93,
+            "C": 0.009,
+            "H": 146
+          }
+        ],
+        "midia": {
+          "img": 14,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 2.84,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 0,
+        "emTransicao": 0,
+        "emTransicaoPor1000": 0,
+        "animacoesAtivas": 0,
+        "duracoes": [],
+        "tamTitulos": [
+          38,
+          24
+        ],
+        "workhorse": {
+          "px": 19,
+          "ocorrencias": 2
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 38,
+            "elementos": 1,
+            "caracteres": 7,
+            "palavras": 1,
+            "textos": [
+              "¡Hello!"
+            ],
+            "fontFamily": "\"Times New Roman\"",
+            "familiaEfetiva": "Times New Roman",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "times new roman",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "700",
+            "lineHeightPx": "57.6px",
+            "lineHeightRazao": 1.52,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 16,
+            "maiorLarguraCh": 16,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 24,
+            "elementos": 17,
+            "caracteres": 294,
+            "palavras": 37,
+            "textos": [
+              "🔗 FreeSolitaire.win",
+              "🔗 pcg.fragara.com",
+              "📄 Inquiet, quitter, quittance",
+              "🔗 gist:wkpd.js",
+              "🔗 github:TraSSH",
+              "📄 Swaraj"
+            ],
+            "fontFamily": "\"Times New Roman\"",
+            "familiaEfetiva": "Times New Roman",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "times new roman",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "700",
+            "lineHeightPx": "31.2px",
+            "lineHeightRazao": 1.3,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 24,
+            "maiorLarguraCh": 24,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 19,
+          "fontFamily": "\"Times New Roman\"",
+          "familiaEfetiva": "Times New Roman",
+          "familiaVerificada": true,
+          "serifa": true,
+          "lineHeightPx": "28.8px",
+          "lineHeightRazao": 1.52,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 32
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            38,
+            24
+          ],
+          "workhorse_semFiltro": {
+            "px": 19,
+            "ocorrencias": 2
+          },
+          "razao_semFiltro": 2,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Times New Roman\"",
+            "contagem": 20
+          },
+          {
+            "familia": "monospace",
+            "contagem": 2
+          },
+          {
+            "familia": "system-ui",
+            "contagem": 1
+          },
+          {
+            "familia": "sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 38,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 7,
+          "palavras": 1,
+          "fontFamily": "\"Times New Roman\"",
+          "familiaEfetiva": "Times New Roman",
+          "familiaVerificada": true,
+          "serifa": true,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 2.9
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://paul.fragara.com"
+    },
+    "paulfragara@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:24:00.459Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 4606,
+        "imgs": 14,
+        "carregadas": 14
+      },
+      "data": {
+        "url": "https://paul.fragara.com/",
+        "altura": 4606,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 5.5,
+        "telas_base900_legado": 5.1,
+        "metricaV2_hsvS015": 0.7,
+        "corPerceptivel_C005": 0.7,
+        "corForte_C012": 0.7,
+        "cromaMedioPonderado": 0.015,
+        "cromaPicoOklch": 0.194,
+        "fundos": [
+          {
+            "cor": "rgb(240,255,240)",
+            "pct": 53,
+            "L": 0.98,
+            "C": 0.025,
+            "H": 145
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 45.6,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(248,233,0)",
+            "pct": 0.5,
+            "L": 0.92,
+            "C": 0.194,
+            "H": 105
+          },
+          {
+            "cor": "rgb(102,102,102)",
+            "pct": 0.4,
+            "L": 0.51,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(0,119,0)",
+            "pct": 0.2,
+            "L": 0.49,
+            "C": 0.168,
+            "H": 142
+          },
+          {
+            "cor": "rgb(227,232,227)",
+            "pct": 0.2,
+            "L": 0.93,
+            "C": 0.009,
+            "H": 146
+          }
+        ],
+        "midia": {
+          "img": 14,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 3.04,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 0,
+        "emTransicao": 0,
+        "emTransicaoPor1000": 0,
+        "animacoesAtivas": 0,
+        "duracoes": [],
+        "tamTitulos": [
+          38,
+          24
+        ],
+        "workhorse": {
+          "px": 19,
+          "ocorrencias": 2
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 38,
+            "elementos": 1,
+            "caracteres": 7,
+            "palavras": 1,
+            "textos": [
+              "¡Hello!"
+            ],
+            "fontFamily": "\"Times New Roman\"",
+            "familiaEfetiva": "Times New Roman",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "times new roman",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "700",
+            "lineHeightPx": "57.6px",
+            "lineHeightRazao": 1.52,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 16,
+            "maiorLarguraCh": 16,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 24,
+            "elementos": 17,
+            "caracteres": 294,
+            "palavras": 37,
+            "textos": [
+              "🔗 FreeSolitaire.win",
+              "🔗 pcg.fragara.com",
+              "📄 Inquiet, quitter, quittance",
+              "🔗 gist:wkpd.js",
+              "🔗 github:TraSSH",
+              "📄 Swaraj"
+            ],
+            "fontFamily": "\"Times New Roman\"",
+            "familiaEfetiva": "Times New Roman",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "times new roman",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "700",
+            "lineHeightPx": "31.2px",
+            "lineHeightRazao": 1.3,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 20,
+            "maiorLarguraCh": 30,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 19,
+          "fontFamily": "\"Times New Roman\"",
+          "familiaEfetiva": "Times New Roman",
+          "familiaVerificada": true,
+          "serifa": true,
+          "lineHeightPx": "28.8px",
+          "lineHeightRazao": 1.52,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 39
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            38,
+            24
+          ],
+          "workhorse_semFiltro": {
+            "px": 19,
+            "ocorrencias": 2
+          },
+          "razao_semFiltro": 2,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Times New Roman\"",
+            "contagem": 20
+          },
+          {
+            "familia": "monospace",
+            "contagem": 2
+          },
+          {
+            "familia": "system-ui",
+            "contagem": 1
+          },
+          {
+            "familia": "sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 38,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 7,
+          "palavras": 1,
+          "fontFamily": "\"Times New Roman\"",
+          "familiaEfetiva": "Times New Roman",
+          "familiaVerificada": true,
+          "serifa": true,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 3.1
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://paul.fragara.com"
+    },
+    "paulfragara@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:24:11.853Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 2452,
+        "imgs": 14,
+        "carregadas": 14
+      },
+      "data": {
+        "url": "https://paul.fragara.com/",
+        "altura": 2452,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 2.4,
+        "telas_base900_legado": 2.7,
+        "metricaV2_hsvS015": 0.7,
+        "corPerceptivel_C005": 0.7,
+        "corForte_C012": 0.7,
+        "cromaMedioPonderado": 0.015,
+        "cromaPicoOklch": 0.194,
+        "fundos": [
+          {
+            "cor": "rgb(240,255,240)",
+            "pct": 54.3,
+            "L": 0.98,
+            "C": 0.025,
+            "H": 145
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 44.4,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(248,233,0)",
+            "pct": 0.5,
+            "L": 0.92,
+            "C": 0.194,
+            "H": 105
+          },
+          {
+            "cor": "rgb(102,102,102)",
+            "pct": 0.4,
+            "L": 0.51,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(0,119,0)",
+            "pct": 0.2,
+            "L": 0.49,
+            "C": 0.168,
+            "H": 142
+          },
+          {
+            "cor": "rgb(227,232,227)",
+            "pct": 0.2,
+            "L": 0.93,
+            "C": 0.009,
+            "H": 146
+          }
+        ],
+        "midia": {
+          "img": 14,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 5.71,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 0,
+        "emTransicao": 0,
+        "emTransicaoPor1000": 0,
+        "animacoesAtivas": 0,
+        "duracoes": [],
+        "tamTitulos": [
+          38,
+          24
+        ],
+        "workhorse": {
+          "px": 19,
+          "ocorrencias": 2
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 38,
+            "elementos": 1,
+            "caracteres": 7,
+            "palavras": 1,
+            "textos": [
+              "¡Hello!"
+            ],
+            "fontFamily": "\"Times New Roman\"",
+            "familiaEfetiva": "Times New Roman",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "times new roman",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "700",
+            "lineHeightPx": "57.6px",
+            "lineHeightRazao": 1.52,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 16,
+            "maiorLarguraCh": 16,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 24,
+            "elementos": 17,
+            "caracteres": 294,
+            "palavras": 37,
+            "textos": [
+              "🔗 FreeSolitaire.win",
+              "🔗 pcg.fragara.com",
+              "📄 Inquiet, quitter, quittance",
+              "🔗 gist:wkpd.js",
+              "🔗 github:TraSSH",
+              "📄 Swaraj"
+            ],
+            "fontFamily": "\"Times New Roman\"",
+            "familiaEfetiva": "Times New Roman",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "times new roman",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "700",
+            "lineHeightPx": "31.2px",
+            "lineHeightRazao": 1.3,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 20,
+            "maiorLarguraCh": 30,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 19,
+          "fontFamily": "\"Times New Roman\"",
+          "familiaEfetiva": "Times New Roman",
+          "familiaVerificada": true,
+          "serifa": true,
+          "lineHeightPx": "28.8px",
+          "lineHeightRazao": 1.52,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 78
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            38,
+            24
+          ],
+          "workhorse_semFiltro": {
+            "px": 19,
+            "ocorrencias": 2
+          },
+          "razao_semFiltro": 2,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Times New Roman\"",
+            "contagem": 20
+          },
+          {
+            "familia": "monospace",
+            "contagem": 2
+          },
+          {
+            "familia": "system-ui",
+            "contagem": 1
+          },
+          {
+            "familia": "sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 38,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 7,
+          "palavras": 1,
+          "fontFamily": "\"Times New Roman\"",
+          "familiaEfetiva": "Times New Roman",
+          "familiaVerificada": true,
+          "serifa": true,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 0.3
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            38,
+            24
+          ],
+          "maiorTexto": 38
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://paul.fragara.com"
+    },
+    "lowmess@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:24:23.501Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 1911,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "https://lowmess.com/",
+        "altura": 1911,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 10
+        },
+        "viewportMedido": {
+          "w": 320,
+          "h": 568,
+          "dpr": 2
+        },
+        "telas": 3.4,
+        "telas_base900_legado": 2.1,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(59,59,59)",
+            "pct": 100,
+            "L": 0.35,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 4,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 2.09,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 0,
+        "emTransicao": 8,
+        "emTransicaoPor1000": 4.19,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            7
+          ],
+          [
+            "0.5s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          48,
+          16,
+          13
+        ],
+        "workhorse": {
+          "px": 13,
+          "ocorrencias": 17
+        },
+        "razaoTituloWorkhorse": 3.69,
+        "titulosDetalhes": [
+          {
+            "px": 48,
+            "elementos": 1,
+            "caracteres": 43,
+            "palavras": 9,
+            "textos": [
+              "My name is Alec Lomas, and I make websites."
+            ],
+            "fontFamily": "Framboisier-c5b887b96a812672, \"Framboisier-c5b887b96a812672 fallback: Times New Roman\", Georgia, ui-serif, serif",
+            "familiaEfetiva": "Framboisier-c5b887b96a812672",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "framboisier-c5b887b96a812672",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "47.7763px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 8,
+            "maiorLarguraCh": 8,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 16,
+            "elementos": 2,
+            "caracteres": 28,
+            "palavras": 4,
+            "textos": [
+              "Introduction",
+              "Latest blog post"
+            ],
+            "fontFamily": "\"Hanken Grotesk-64878f986bd13d12\", \"Hanken Grotesk-64878f986bd13d12 fallback: Arial\", ui-sans-serif, system-ui, sans-serif",
+            "familiaEfetiva": "Hanken Grotesk-64878f986bd13d12",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "hanken grotesk-64878f986bd13d12",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "20.0008px",
+            "lineHeightRazao": 1.25,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 28,
+            "maiorLarguraCh": 28,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 13,
+            "elementos": 4,
+            "caracteres": 50,
+            "palavras": 9,
+            "textos": [
+              "Just listened",
+              "Recent writing",
+              "On this site",
+              "Around town"
+            ],
+            "fontFamily": "\"Hanken Grotesk-64878f986bd13d12\", \"Hanken Grotesk-64878f986bd13d12 fallback: Arial\", ui-sans-serif, system-ui, sans-serif",
+            "familiaEfetiva": "Hanken Grotesk-64878f986bd13d12",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "hanken grotesk-64878f986bd13d12",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "16.6672px",
+            "lineHeightRazao": 1.28,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 33,
+            "maiorLarguraCh": 33,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 13,
+          "fontFamily": "\"Hanken Grotesk-64878f986bd13d12\", \"Hanken Grotesk-64878f986bd13d12 fallback: Arial\", ui-sans-serif, system-ui, sans-serif",
+          "familiaEfetiva": "Hanken Grotesk-64878f986bd13d12",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "20.0006px",
+          "lineHeightRazao": 1.54,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 33
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            48,
+            16,
+            13
+          ],
+          "workhorse_semFiltro": {
+            "px": 13,
+            "ocorrencias": 17
+          },
+          "razao_semFiltro": 3.69,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Hanken Grotesk-64878f986bd13d12\", \"Hanken Grotesk-64878f986bd13d12 fallback: Arial\", ui-sans-serif, system-ui, sans-serif",
+            "contagem": 29
+          },
+          {
+            "familia": "Framboisier-c5b887b96a812672, \"Framboisier-c5b887b96a812672 fallback: Times New Roman\", Georgia, ui-serif, serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 48,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 43,
+          "palavras": 9,
+          "fontFamily": "Framboisier-c5b887b96a812672, \"Framboisier-c5b887b96a812672 fallback: Times New Roman\", Georgia, ui-serif, serif",
+          "familiaEfetiva": "Framboisier-c5b887b96a812672",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 4.6
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            48,
+            16,
+            13
+          ],
+          "maiorTexto": 48
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            48,
+            16,
+            13
+          ],
+          "maiorTexto": 48
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            48,
+            16,
+            13
+          ],
+          "maiorTexto": 48
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            48,
+            16,
+            13
+          ],
+          "maiorTexto": 48
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            48,
+            16,
+            13
+          ],
+          "maiorTexto": 48
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://lowmess.com"
+    },
+    "lowmess@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:24:33.550Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 1755,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "https://lowmess.com/",
+        "altura": 1755,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 10
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 2.1,
+        "telas_base900_legado": 2,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(59,59,59)",
+            "pct": 100,
+            "L": 0.35,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 4,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 2.28,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 0,
+        "emTransicao": 8,
+        "emTransicaoPor1000": 4.56,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            7
+          ],
+          [
+            "0.5s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          50,
+          16,
+          14
+        ],
+        "workhorse": {
+          "px": 14,
+          "ocorrencias": 17
+        },
+        "razaoTituloWorkhorse": 3.57,
+        "titulosDetalhes": [
+          {
+            "px": 50,
+            "elementos": 1,
+            "caracteres": 43,
+            "palavras": 9,
+            "textos": [
+              "My name is Alec Lomas, and I make websites."
+            ],
+            "fontFamily": "Framboisier-c5b887b96a812672, \"Framboisier-c5b887b96a812672 fallback: Times New Roman\", Georgia, ui-serif, serif",
+            "familiaEfetiva": "Framboisier-c5b887b96a812672",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "framboisier-c5b887b96a812672",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "49.8557px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 10,
+            "maiorLarguraCh": 10,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 16,
+            "elementos": 2,
+            "caracteres": 28,
+            "palavras": 4,
+            "textos": [
+              "Introduction",
+              "Latest blog post"
+            ],
+            "fontFamily": "\"Hanken Grotesk-64878f986bd13d12\", \"Hanken Grotesk-64878f986bd13d12 fallback: Arial\", ui-sans-serif, system-ui, sans-serif",
+            "familiaEfetiva": "Hanken Grotesk-64878f986bd13d12",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "hanken grotesk-64878f986bd13d12",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "20.3654px",
+            "lineHeightRazao": 1.27,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 35,
+            "maiorLarguraCh": 35,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 14,
+            "elementos": 4,
+            "caracteres": 50,
+            "palavras": 9,
+            "textos": [
+              "Just listened",
+              "Recent writing",
+              "On this site",
+              "Around town"
+            ],
+            "fontFamily": "\"Hanken Grotesk-64878f986bd13d12\", \"Hanken Grotesk-64878f986bd13d12 fallback: Arial\", ui-sans-serif, system-ui, sans-serif",
+            "familiaEfetiva": "Hanken Grotesk-64878f986bd13d12",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "hanken grotesk-64878f986bd13d12",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "16.9103px",
+            "lineHeightRazao": 1.21,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 42,
+            "maiorLarguraCh": 42,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 14,
+          "fontFamily": "\"Hanken Grotesk-64878f986bd13d12\", \"Hanken Grotesk-64878f986bd13d12 fallback: Arial\", ui-sans-serif, system-ui, sans-serif",
+          "familiaEfetiva": "Hanken Grotesk-64878f986bd13d12",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "20.2923px",
+          "lineHeightRazao": 1.45,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 42
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            50,
+            16,
+            14
+          ],
+          "workhorse_semFiltro": {
+            "px": 14,
+            "ocorrencias": 17
+          },
+          "razao_semFiltro": 3.57,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Hanken Grotesk-64878f986bd13d12\", \"Hanken Grotesk-64878f986bd13d12 fallback: Arial\", ui-sans-serif, system-ui, sans-serif",
+            "contagem": 29
+          },
+          {
+            "familia": "Framboisier-c5b887b96a812672, \"Framboisier-c5b887b96a812672 fallback: Times New Roman\", Georgia, ui-serif, serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 50,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 43,
+          "palavras": 9,
+          "fontFamily": "Framboisier-c5b887b96a812672, \"Framboisier-c5b887b96a812672 fallback: Times New Roman\", Georgia, ui-serif, serif",
+          "familiaEfetiva": "Framboisier-c5b887b96a812672",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 5
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            50,
+            16,
+            14
+          ],
+          "maiorTexto": 50
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            50,
+            16,
+            14
+          ],
+          "maiorTexto": 50
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            50,
+            16,
+            14
+          ],
+          "maiorTexto": 50
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            50,
+            16,
+            14
+          ],
+          "maiorTexto": 50
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            50,
+            16,
+            14
+          ],
+          "maiorTexto": 50
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://lowmess.com"
+    },
+    "lowmess@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:24:43.568Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 1026,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "https://lowmess.com/",
+        "altura": 1026,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 10
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 1,
+        "telas_base900_legado": 1.1,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(59,59,59)",
+            "pct": 100,
+            "L": 0.35,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 4,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 3.9,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 0,
+        "emTransicao": 8,
+        "emTransicaoPor1000": 7.8,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            7
+          ],
+          [
+            "0.5s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          61,
+          18,
+          15
+        ],
+        "workhorse": {
+          "px": 15,
+          "ocorrencias": 17
+        },
+        "razaoTituloWorkhorse": 4.07,
+        "titulosDetalhes": [
+          {
+            "px": 61,
+            "elementos": 1,
+            "caracteres": 43,
+            "palavras": 9,
+            "textos": [
+              "My name is Alec Lomas, and I make websites."
+            ],
+            "fontFamily": "Framboisier-c5b887b96a812672, \"Framboisier-c5b887b96a812672 fallback: Times New Roman\", Georgia, ui-serif, serif",
+            "familiaEfetiva": "Framboisier-c5b887b96a812672",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "framboisier-c5b887b96a812672",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "61.0846px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 18,
+            "maiorLarguraCh": 18,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 2,
+            "caracteres": 28,
+            "palavras": 4,
+            "textos": [
+              "Introduction",
+              "Latest blog post"
+            ],
+            "fontFamily": "\"Hanken Grotesk-64878f986bd13d12\", \"Hanken Grotesk-64878f986bd13d12 fallback: Arial\", ui-sans-serif, system-ui, sans-serif",
+            "familiaEfetiva": "Hanken Grotesk-64878f986bd13d12",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "hanken grotesk-64878f986bd13d12",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "22.3343px",
+            "lineHeightRazao": 1.24,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 68,
+            "maiorLarguraCh": 68,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 15,
+            "elementos": 4,
+            "caracteres": 50,
+            "palavras": 9,
+            "textos": [
+              "Just listened",
+              "Recent writing",
+              "On this site",
+              "Around town"
+            ],
+            "fontFamily": "\"Hanken Grotesk-64878f986bd13d12\", \"Hanken Grotesk-64878f986bd13d12 fallback: Arial\", ui-sans-serif, system-ui, sans-serif",
+            "familiaEfetiva": "Hanken Grotesk-64878f986bd13d12",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "hanken grotesk-64878f986bd13d12",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "18.2229px",
+            "lineHeightRazao": 1.21,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 10,
+            "maiorLarguraCh": 11,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 15,
+          "fontFamily": "\"Hanken Grotesk-64878f986bd13d12\", \"Hanken Grotesk-64878f986bd13d12 fallback: Arial\", ui-sans-serif, system-ui, sans-serif",
+          "familiaEfetiva": "Hanken Grotesk-64878f986bd13d12",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "21.8675px",
+          "lineHeightRazao": 1.46,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 41
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            61,
+            18,
+            15
+          ],
+          "workhorse_semFiltro": {
+            "px": 15,
+            "ocorrencias": 17
+          },
+          "razao_semFiltro": 4.07,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Hanken Grotesk-64878f986bd13d12\", \"Hanken Grotesk-64878f986bd13d12 fallback: Arial\", ui-sans-serif, system-ui, sans-serif",
+            "contagem": 29
+          },
+          {
+            "familia": "Framboisier-c5b887b96a812672, \"Framboisier-c5b887b96a812672 fallback: Times New Roman\", Georgia, ui-serif, serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 61,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 43,
+          "palavras": 9,
+          "fontFamily": "Framboisier-c5b887b96a812672, \"Framboisier-c5b887b96a812672 fallback: Times New Roman\", Georgia, ui-serif, serif",
+          "familiaEfetiva": "Framboisier-c5b887b96a812672",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 8.8
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            61,
+            18,
+            15
+          ],
+          "maiorTexto": 61
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            61,
+            18,
+            15
+          ],
+          "maiorTexto": 61
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            61,
+            18,
+            15
+          ],
+          "maiorTexto": 61
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            61,
+            18,
+            15
+          ],
+          "maiorTexto": 61
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            61,
+            18,
+            15
+          ],
+          "maiorTexto": 61
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://lowmess.com"
+    },
+    "simonbetton@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:24:55.684Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 10012,
+        "imgs": 14,
+        "carregadas": 4
+      },
+      "data": {
+        "url": "https://www.simonbetton.com/",
+        "altura": 10012,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 4
+        },
+        "viewportMedido": {
+          "w": 359,
+          "h": 638,
+          "dpr": 2
+        },
+        "telas": 15.7,
+        "telas_base900_legado": 11.1,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 100,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 14,
+          "svg": 23,
+          "video": 0,
+          "canvas": 1
+        },
+        "midiaTotalPor1000": 3.8,
+        "keyframes": 14,
+        "nomes": [
+          "aui-pulse",
+          "work-card-parallax",
+          "spin",
+          "pulse",
+          "enter",
+          "exit",
+          "collapsible-down",
+          "collapsible-up",
+          "tw-shimmer",
+          "profile-bounce",
+          "profile-fade",
+          "mobile-profile-tab-nav-enter",
+          "route-content-out",
+          "route-content-in"
+        ],
+        "keyframesPor1000": 1.4,
+        "folhasBloqueadas": 0,
+        "emTransicao": 84,
+        "emTransicaoPor1000": 8.39,
+        "animacoesAtivas": 4,
+        "duracoes": [
+          [
+            "0.18s",
+            47
+          ],
+          [
+            "0.4s",
+            12
+          ],
+          [
+            "0.15s",
+            9
+          ],
+          [
+            "0.1s",
+            7
+          ],
+          [
+            "0.2s",
+            4
+          ],
+          [
+            "0.125s",
+            2
+          ],
+          [
+            "0.3s",
+            1
+          ],
+          [
+            "0.225s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          20,
+          18,
+          16,
+          14
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 10
+        },
+        "razaoTituloWorkhorse": 1.25,
+        "titulosDetalhes": [
+          {
+            "px": 20,
+            "elementos": 1,
+            "caracteres": 269,
+            "palavras": 40,
+            "textos": [
+              "A principal software engineer with over 19 years of experience across backend and frontend. I design architecture that s"
+            ],
+            "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "familiaEfetiva": "Figtree Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "figtree variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "32.5px",
+            "lineHeightRazao": 1.63,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.1808px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 25,
+            "maiorLarguraCh": 25,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 1,
+            "caracteres": 324,
+            "palavras": 48,
+            "textos": [
+              "Currently at House of Doge, responsible for the architecture and technical strategy of a greenfield React Native platfor"
+            ],
+            "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "familiaEfetiva": "Figtree Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "figtree variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "29.25px",
+            "lineHeightRazao": 1.63,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.1808px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 28,
+            "maiorLarguraCh": 28,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 16,
+            "elementos": 2,
+            "caracteres": 42,
+            "palavras": 7,
+            "textos": [
+              "Latest open-source projects —",
+              "Recent work —"
+            ],
+            "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "familiaEfetiva": "Figtree Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "figtree variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "26px",
+            "lineHeightRazao": 1.63,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.1808px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 32,
+            "maiorLarguraCh": 32,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 14,
+            "elementos": 7,
+            "caracteres": 117,
+            "palavras": 7,
+            "textos": [
+              "ratesapi.nz",
+              "expo-easy-passkey",
+              "expo-device-auth",
+              "easydoge-km",
+              "dogecoin-payment-button",
+              "connect.onlydoge.io"
+            ],
+            "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "familiaEfetiva": "Figtree Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "figtree variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "22.75px",
+            "lineHeightRazao": 1.63,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.1808px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 8,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+          "familiaEfetiva": "Figtree Variable",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "26px",
+          "lineHeightRazao": 1.63,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 32
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 34
+          },
+          "razao_semFiltro": 1.25,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "contagem": 30
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 20,
+          "tag": "h1",
+          "className": "font-sans font-medium text-pretty text-primary text-xl leading-relaxed tracking-[-0.0113rem] 2xl:text-2xl 2xl:leading-loose",
+          "caracteres": 269,
+          "palavras": 40,
+          "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+          "familiaEfetiva": "Figtree Variable",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "500",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 2.5
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://simonbetton.com"
+    },
+    "simonbetton@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:25:06.996Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 9960,
+        "imgs": 14,
+        "carregadas": 4
+      },
+      "data": {
+        "url": "https://www.simonbetton.com/",
+        "altura": 9960,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 4
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 11.8,
+        "telas_base900_legado": 11.1,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 100,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 14,
+          "svg": 23,
+          "video": 0,
+          "canvas": 1
+        },
+        "midiaTotalPor1000": 3.82,
+        "keyframes": 14,
+        "nomes": [
+          "aui-pulse",
+          "work-card-parallax",
+          "spin",
+          "pulse",
+          "enter",
+          "exit",
+          "collapsible-down",
+          "collapsible-up",
+          "tw-shimmer",
+          "profile-bounce",
+          "profile-fade",
+          "mobile-profile-tab-nav-enter",
+          "route-content-out",
+          "route-content-in"
+        ],
+        "keyframesPor1000": 1.41,
+        "folhasBloqueadas": 0,
+        "emTransicao": 84,
+        "emTransicaoPor1000": 8.43,
+        "animacoesAtivas": 4,
+        "duracoes": [
+          [
+            "0.18s",
+            47
+          ],
+          [
+            "0.4s",
+            12
+          ],
+          [
+            "0.15s",
+            9
+          ],
+          [
+            "0.1s",
+            7
+          ],
+          [
+            "0.2s",
+            4
+          ],
+          [
+            "0.125s",
+            2
+          ],
+          [
+            "0.3s",
+            1
+          ],
+          [
+            "0.225s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          20,
+          18,
+          16,
+          14
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 10
+        },
+        "razaoTituloWorkhorse": 1.25,
+        "titulosDetalhes": [
+          {
+            "px": 20,
+            "elementos": 1,
+            "caracteres": 269,
+            "palavras": 40,
+            "textos": [
+              "A principal software engineer with over 19 years of experience across backend and frontend. I design architecture that s"
+            ],
+            "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "familiaEfetiva": "Figtree Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "figtree variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "32.5px",
+            "lineHeightRazao": 1.63,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.1808px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 28,
+            "maiorLarguraCh": 28,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 1,
+            "caracteres": 324,
+            "palavras": 48,
+            "textos": [
+              "Currently at House of Doge, responsible for the architecture and technical strategy of a greenfield React Native platfor"
+            ],
+            "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "familiaEfetiva": "Figtree Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "figtree variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "29.25px",
+            "lineHeightRazao": 1.63,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.1808px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 31,
+            "maiorLarguraCh": 31,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 16,
+            "elementos": 2,
+            "caracteres": 42,
+            "palavras": 7,
+            "textos": [
+              "Latest open-source projects —",
+              "Recent work —"
+            ],
+            "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "familiaEfetiva": "Figtree Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "figtree variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "26px",
+            "lineHeightRazao": 1.63,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.1808px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 35,
+            "maiorLarguraCh": 35,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 14,
+            "elementos": 7,
+            "caracteres": 117,
+            "palavras": 7,
+            "textos": [
+              "ratesapi.nz",
+              "expo-easy-passkey",
+              "expo-device-auth",
+              "easydoge-km",
+              "dogecoin-payment-button",
+              "connect.onlydoge.io"
+            ],
+            "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "familiaEfetiva": "Figtree Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "figtree variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "22.75px",
+            "lineHeightRazao": 1.63,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.1808px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 8,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+          "familiaEfetiva": "Figtree Variable",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "26px",
+          "lineHeightRazao": 1.63,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 35
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 34
+          },
+          "razao_semFiltro": 1.25,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "contagem": 30
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 20,
+          "tag": "h1",
+          "className": "font-sans font-medium text-pretty text-primary text-xl leading-relaxed tracking-[-0.0113rem] 2xl:text-2xl 2xl:leading-loose",
+          "caracteres": 269,
+          "palavras": 40,
+          "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+          "familiaEfetiva": "Figtree Variable",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "500",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 2.5
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://simonbetton.com"
+    },
+    "simonbetton@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:25:18.500Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 11577,
+        "imgs": 14,
+        "carregadas": 4
+      },
+      "data": {
+        "url": "https://www.simonbetton.com/",
+        "altura": 11577,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 4
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 11.3,
+        "telas_base900_legado": 12.9,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 100,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 14,
+          "svg": 23,
+          "video": 0,
+          "canvas": 1
+        },
+        "midiaTotalPor1000": 3.28,
+        "keyframes": 14,
+        "nomes": [
+          "aui-pulse",
+          "work-card-parallax",
+          "spin",
+          "pulse",
+          "enter",
+          "exit",
+          "collapsible-down",
+          "collapsible-up",
+          "tw-shimmer",
+          "profile-bounce",
+          "profile-fade",
+          "mobile-profile-tab-nav-enter",
+          "route-content-out",
+          "route-content-in"
+        ],
+        "keyframesPor1000": 1.21,
+        "folhasBloqueadas": 0,
+        "emTransicao": 84,
+        "emTransicaoPor1000": 7.26,
+        "animacoesAtivas": 4,
+        "duracoes": [
+          [
+            "0.18s",
+            47
+          ],
+          [
+            "0.4s",
+            12
+          ],
+          [
+            "0.15s",
+            9
+          ],
+          [
+            "0.1s",
+            7
+          ],
+          [
+            "0.2s",
+            4
+          ],
+          [
+            "0.125s",
+            2
+          ],
+          [
+            "0.3s",
+            1
+          ],
+          [
+            "0.225s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          20,
+          18,
+          16,
+          14
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 10
+        },
+        "razaoTituloWorkhorse": 1.25,
+        "titulosDetalhes": [
+          {
+            "px": 20,
+            "elementos": 1,
+            "caracteres": 269,
+            "palavras": 40,
+            "textos": [
+              "A principal software engineer with over 19 years of experience across backend and frontend. I design architecture that s"
+            ],
+            "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "familiaEfetiva": "Figtree Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "figtree variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "32.5px",
+            "lineHeightRazao": 1.63,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.1808px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 54,
+            "maiorLarguraCh": 54,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 1,
+            "caracteres": 324,
+            "palavras": 48,
+            "textos": [
+              "Currently at House of Doge, responsible for the architecture and technical strategy of a greenfield React Native platfor"
+            ],
+            "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "familiaEfetiva": "Figtree Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "figtree variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "29.25px",
+            "lineHeightRazao": 1.63,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.1808px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 60,
+            "maiorLarguraCh": 60,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 16,
+            "elementos": 2,
+            "caracteres": 42,
+            "palavras": 7,
+            "textos": [
+              "Latest open-source projects —",
+              "Recent work —"
+            ],
+            "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "familiaEfetiva": "Figtree Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "figtree variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "26px",
+            "lineHeightRazao": 1.63,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.1808px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 68,
+            "maiorLarguraCh": 68,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 14,
+            "elementos": 7,
+            "caracteres": 117,
+            "palavras": 7,
+            "textos": [
+              "ratesapi.nz",
+              "expo-easy-passkey",
+              "expo-device-auth",
+              "easydoge-km",
+              "dogecoin-payment-button",
+              "connect.onlydoge.io"
+            ],
+            "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "familiaEfetiva": "Figtree Variable",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "figtree variable",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "22.75px",
+            "lineHeightRazao": 1.63,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.1808px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 8,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+          "familiaEfetiva": "Figtree Variable",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "26px",
+          "lineHeightRazao": 1.63,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 68
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 34
+          },
+          "razao_semFiltro": 1.25,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+            "contagem": 30
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 20,
+          "tag": "h1",
+          "className": "font-sans font-medium text-pretty text-primary text-xl leading-relaxed tracking-[-0.0113rem] 2xl:text-2xl 2xl:leading-loose",
+          "caracteres": 269,
+          "palavras": 40,
+          "fontFamily": "\"Figtree Variable\", \"Figtree Fallback\", sans-serif",
+          "familiaEfetiva": "Figtree Variable",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "500",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 2.2
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            20,
+            18,
+            16,
+            14
+          ],
+          "maiorTexto": 20
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://simonbetton.com"
+    },
+    "nextfive@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:25:30.253Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 4053,
+        "imgs": 8,
+        "carregadas": 8
+      },
+      "data": {
+        "url": "https://nextfive.xyz/",
+        "altura": 4053,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 40
+        },
+        "viewportMedido": {
+          "w": 370,
+          "h": 657,
+          "dpr": 2
+        },
+        "telas": 6.2,
+        "telas_base900_legado": 4.5,
+        "metricaV2_hsvS015": 100,
+        "corPerceptivel_C005": 19.1,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0.021,
+        "cromaPicoOklch": 0.052,
+        "fundos": [
+          {
+            "cor": "rgb(39,46,51)",
+            "pct": 79.8,
+            "L": 0.3,
+            "C": 0.013,
+            "H": 239
+          },
+          {
+            "cor": "rgb(7,54,66)",
+            "pct": 19.1,
+            "L": 0.31,
+            "C": 0.052,
+            "H": 220
+          },
+          {
+            "cor": "rgb(26,30,36)",
+            "pct": 0.8,
+            "L": 0.23,
+            "C": 0.013,
+            "H": 258
+          },
+          {
+            "cor": "rgb(45,51,59)",
+            "pct": 0.3,
+            "L": 0.32,
+            "C": 0.017,
+            "H": 256
+          }
+        ],
+        "midia": {
+          "img": 8,
+          "svg": 2,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 2.47,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 0,
+        "emTransicao": 168,
+        "emTransicaoPor1000": 41.45,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            372
+          ],
+          [
+            "0.2s",
+            43
+          ]
+        ],
+        "tamTitulos": [
+          32,
+          29,
+          24,
+          21,
+          16
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 18
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 32,
+            "elementos": 1,
+            "caracteres": 13,
+            "palavras": 3,
+            "textos": [
+              "Hi, I’m Amit!"
+            ],
+            "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "familiaEfetiva": "Inter",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "38.4px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 14,
+            "maiorLarguraCh": 14,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 29,
+            "elementos": 1,
+            "caracteres": 14,
+            "palavras": 2,
+            "textos": [
+              "Amit @NextFive"
+            ],
+            "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "familiaEfetiva": "Inter",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "34.56px",
+            "lineHeightRazao": 1.19,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 15,
+            "maiorLarguraCh": 15,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 24,
+            "elementos": 5,
+            "caracteres": 68,
+            "palavras": 11,
+            "textos": [
+              "Me in 10 seconds",
+              "Contact me",
+              "Recent projects",
+              "Photography projects",
+              "Writing"
+            ],
+            "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "familiaEfetiva": "Inter",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "28.8px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 19,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 21,
+            "elementos": 3,
+            "caracteres": 36,
+            "palavras": 6,
+            "textos": [
+              "Art",
+              "Absent",
+              "40 minutes and bird-by-bird"
+            ],
+            "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "familiaEfetiva": "Inter",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "27.04px",
+            "lineHeightRazao": 1.29,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 2,
+            "maiorLarguraCh": 18,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 16,
+            "elementos": 1,
+            "caracteres": 22,
+            "palavras": 4,
+            "textos": [
+              "Recent Posts (see all)"
+            ],
+            "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "familiaEfetiva": "Inter",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "19.2px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 28,
+            "maiorLarguraCh": 28,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "27.2px",
+          "lineHeightRazao": 1.7,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 30
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            32,
+            29,
+            24,
+            21,
+            16
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 18
+          },
+          "razao_semFiltro": 2,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "contagem": 30
+          },
+          {
+            "familia": "sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 32,
+          "tag": "h2",
+          "className": "",
+          "caracteres": 13,
+          "palavras": 3,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "600",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 9.4
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            32,
+            29,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            32,
+            29,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            32,
+            29,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            32,
+            29,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            32,
+            29,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://nextfive.xyz"
+    },
+    "nextfive@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:25:40.857Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 3603,
+        "imgs": 8,
+        "carregadas": 8
+      },
+      "data": {
+        "url": "https://nextfive.xyz/",
+        "altura": 3603,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 40
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 4.3,
+        "telas_base900_legado": 4,
+        "metricaV2_hsvS015": 100,
+        "corPerceptivel_C005": 19.5,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0.021,
+        "cromaPicoOklch": 0.052,
+        "fundos": [
+          {
+            "cor": "rgb(39,46,51)",
+            "pct": 79.3,
+            "L": 0.3,
+            "C": 0.013,
+            "H": 239
+          },
+          {
+            "cor": "rgb(7,54,66)",
+            "pct": 19.5,
+            "L": 0.31,
+            "C": 0.052,
+            "H": 220
+          },
+          {
+            "cor": "rgb(26,30,36)",
+            "pct": 1,
+            "L": 0.23,
+            "C": 0.013,
+            "H": 258
+          },
+          {
+            "cor": "rgb(45,51,59)",
+            "pct": 0.3,
+            "L": 0.32,
+            "C": 0.017,
+            "H": 256
+          }
+        ],
+        "midia": {
+          "img": 8,
+          "svg": 2,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 2.78,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 0,
+        "emTransicao": 168,
+        "emTransicaoPor1000": 46.63,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            372
+          ],
+          [
+            "0.2s",
+            43
+          ]
+        ],
+        "tamTitulos": [
+          32,
+          29,
+          24,
+          21,
+          16
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 18
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 32,
+            "elementos": 1,
+            "caracteres": 13,
+            "palavras": 3,
+            "textos": [
+              "Hi, I’m Amit!"
+            ],
+            "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "familiaEfetiva": "Inter",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "38.4px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 18,
+            "maiorLarguraCh": 18,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 29,
+            "elementos": 1,
+            "caracteres": 14,
+            "palavras": 2,
+            "textos": [
+              "Amit @NextFive"
+            ],
+            "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "familiaEfetiva": "Inter",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "34.56px",
+            "lineHeightRazao": 1.19,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 19,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 24,
+            "elementos": 5,
+            "caracteres": 68,
+            "palavras": 11,
+            "textos": [
+              "Me in 10 seconds",
+              "Contact me",
+              "Recent projects",
+              "Photography projects",
+              "Writing"
+            ],
+            "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "familiaEfetiva": "Inter",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "28.8px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 23,
+            "maiorLarguraCh": 23,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 21,
+            "elementos": 3,
+            "caracteres": 36,
+            "palavras": 6,
+            "textos": [
+              "Art",
+              "Absent",
+              "40 minutes and bird-by-bird"
+            ],
+            "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "familiaEfetiva": "Inter",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "27.04px",
+            "lineHeightRazao": 1.29,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 2,
+            "maiorLarguraCh": 21,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 16,
+            "elementos": 1,
+            "caracteres": 22,
+            "palavras": 4,
+            "textos": [
+              "Recent Posts (see all)"
+            ],
+            "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "familiaEfetiva": "Inter",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "19.2px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 35,
+            "maiorLarguraCh": 35,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "27.2px",
+          "lineHeightRazao": 1.7,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 37
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            32,
+            29,
+            24,
+            21,
+            16
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 18
+          },
+          "razao_semFiltro": 2,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "contagem": 30
+          },
+          {
+            "familia": "sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 32,
+          "tag": "h2",
+          "className": "",
+          "caracteres": 13,
+          "palavras": 3,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "600",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 10.6
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            32,
+            29,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            32,
+            29,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            32,
+            29,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            32,
+            29,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            32,
+            29,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://nextfive.xyz"
+    },
+    "nextfive@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:25:51.154Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 2970,
+        "imgs": 8,
+        "carregadas": 8
+      },
+      "data": {
+        "url": "https://nextfive.xyz/",
+        "altura": 2970,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 40
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 2.9,
+        "telas_base900_legado": 3.3,
+        "metricaV2_hsvS015": 100,
+        "corPerceptivel_C005": 19,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0.021,
+        "cromaPicoOklch": 0.052,
+        "fundos": [
+          {
+            "cor": "rgb(39,46,51)",
+            "pct": 80.2,
+            "L": 0.3,
+            "C": 0.013,
+            "H": 239
+          },
+          {
+            "cor": "rgb(7,54,66)",
+            "pct": 19,
+            "L": 0.31,
+            "C": 0.052,
+            "H": 220
+          },
+          {
+            "cor": "rgb(26,30,36)",
+            "pct": 0.6,
+            "L": 0.23,
+            "C": 0.013,
+            "H": 258
+          },
+          {
+            "cor": "rgb(45,51,59)",
+            "pct": 0.2,
+            "L": 0.32,
+            "C": 0.017,
+            "H": 256
+          }
+        ],
+        "midia": {
+          "img": 8,
+          "svg": 2,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 3.37,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 0,
+        "emTransicao": 168,
+        "emTransicaoPor1000": 56.57,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            372
+          ],
+          [
+            "0.2s",
+            43
+          ]
+        ],
+        "tamTitulos": [
+          32,
+          24,
+          21,
+          16
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 18
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 32,
+            "elementos": 2,
+            "caracteres": 27,
+            "palavras": 5,
+            "textos": [
+              "Amit @NextFive",
+              "Hi, I’m Amit!"
+            ],
+            "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "familiaEfetiva": "Inter",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "38.4px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 34,
+            "maiorLarguraCh": 35,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 24,
+            "elementos": 5,
+            "caracteres": 68,
+            "palavras": 11,
+            "textos": [
+              "Me in 10 seconds",
+              "Contact me",
+              "Recent projects",
+              "Photography projects",
+              "Writing"
+            ],
+            "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "familiaEfetiva": "Inter",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "28.8px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 47,
+            "maiorLarguraCh": 47,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 21,
+            "elementos": 3,
+            "caracteres": 36,
+            "palavras": 6,
+            "textos": [
+              "Art",
+              "Absent",
+              "40 minutes and bird-by-bird"
+            ],
+            "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "familiaEfetiva": "Inter",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "27.04px",
+            "lineHeightRazao": 1.29,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 2,
+            "maiorLarguraCh": 21,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 16,
+            "elementos": 1,
+            "caracteres": 22,
+            "palavras": 4,
+            "textos": [
+              "Recent Posts (see all)"
+            ],
+            "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "familiaEfetiva": "Inter",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "inter",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "19.2px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 70,
+            "maiorLarguraCh": 70,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "27.2px",
+          "lineHeightRazao": 1.7,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 73
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            32,
+            24,
+            21,
+            16
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 18
+          },
+          "razao_semFiltro": 2,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+            "contagem": 30
+          },
+          {
+            "familia": "sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 32,
+          "tag": "a",
+          "className": "",
+          "caracteres": 14,
+          "palavras": 2,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 0.6
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            32,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            32,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            32,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            32,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            32,
+            24,
+            21,
+            16
+          ],
+          "maiorTexto": 32
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://nextfive.xyz"
+    },
+    "incomescrane@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:26:02.941Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 4309,
+        "imgs": 8,
+        "carregadas": 5
+      },
+      "data": {
+        "url": "https://incomescrane.com/",
+        "altura": 4309,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 28
+        },
+        "viewportMedido": {
+          "w": 351,
+          "h": 624,
+          "dpr": 2
+        },
+        "telas": 6.9,
+        "telas_base900_legado": 4.8,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0.001,
+        "cromaPicoOklch": 0.003,
+        "fundos": [
+          {
+            "cor": "rgb(219,218,216)",
+            "pct": 50,
+            "L": 0.89,
+            "C": 0.003,
+            "H": 85
+          },
+          {
+            "cor": "rgb(239,239,239)",
+            "pct": 50,
+            "L": 0.95,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 0.1,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 8,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 1.86,
+        "keyframes": 2,
+        "nomes": [
+          "fadeInOut-1",
+          "fadeInOut-2"
+        ],
+        "keyframesPor1000": 0.46,
+        "folhasBloqueadas": 1,
+        "emTransicao": 2,
+        "emTransicaoPor1000": 0.46,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            2
+          ]
+        ],
+        "tamTitulos": [
+          32
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 35
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 32,
+            "elementos": 4,
+            "caracteres": 25,
+            "palavras": 4,
+            "textos": [
+              "ABOUT",
+              "PROJECTS",
+              "MEDIA",
+              "CONTACT"
+            ],
+            "fontFamily": "\"IBM Plex Mono\", monospace",
+            "familiaEfetiva": "IBM Plex Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ibm plex mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "35.2px",
+            "lineHeightRazao": 1.1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 14,
+            "maiorLarguraCh": 14,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"IBM Plex Mono\", monospace",
+          "familiaEfetiva": "IBM Plex Mono",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "16px",
+          "lineHeightRazao": 1,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 28
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            68,
+            32
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 35
+          },
+          "razao_semFiltro": 4.25,
+          "divergeDoCorrigido": true
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 68,
+              "motivo": "display:none",
+              "texto": "portfolio"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 4,
+          "caracteresTotais": 25,
+          "caracteresPor1000px": 5.8,
+          "semNeutralizar": 4,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"IBM Plex Mono\", monospace",
+            "contagem": 41
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 32,
+          "tag": "h2",
+          "className": "",
+          "caracteres": 5,
+          "palavras": 1,
+          "fontFamily": "\"IBM Plex Mono\", monospace",
+          "familiaEfetiva": "IBM Plex Mono",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "500",
+          "textTransform": "uppercase",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 15.4
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://incomescrane.com"
+    },
+    "incomescrane@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:26:13.316Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 3756,
+        "imgs": 8,
+        "carregadas": 5
+      },
+      "data": {
+        "url": "https://incomescrane.com/",
+        "altura": 3756,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 28
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 4.5,
+        "telas_base900_legado": 4.2,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0.001,
+        "cromaPicoOklch": 0.003,
+        "fundos": [
+          {
+            "cor": "rgb(219,218,216)",
+            "pct": 50,
+            "L": 0.89,
+            "C": 0.003,
+            "H": 85
+          },
+          {
+            "cor": "rgb(239,239,239)",
+            "pct": 50,
+            "L": 0.95,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 0.1,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 8,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 2.13,
+        "keyframes": 2,
+        "nomes": [
+          "fadeInOut-1",
+          "fadeInOut-2"
+        ],
+        "keyframesPor1000": 0.53,
+        "folhasBloqueadas": 1,
+        "emTransicao": 2,
+        "emTransicaoPor1000": 0.53,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            2
+          ]
+        ],
+        "tamTitulos": [
+          32
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 35
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 32,
+            "elementos": 4,
+            "caracteres": 25,
+            "palavras": 4,
+            "textos": [
+              "ABOUT",
+              "PROJECTS",
+              "MEDIA",
+              "CONTACT"
+            ],
+            "fontFamily": "\"IBM Plex Mono\", monospace",
+            "familiaEfetiva": "IBM Plex Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ibm plex mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "35.2px",
+            "lineHeightRazao": 1.1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 18,
+            "maiorLarguraCh": 18,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"IBM Plex Mono\", monospace",
+          "familiaEfetiva": "IBM Plex Mono",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "16px",
+          "lineHeightRazao": 1,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 35
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            68,
+            32
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 35
+          },
+          "razao_semFiltro": 4.25,
+          "divergeDoCorrigido": true
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 68,
+              "motivo": "display:none",
+              "texto": "portfolio"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 4,
+          "caracteresTotais": 25,
+          "caracteresPor1000px": 6.66,
+          "semNeutralizar": 4,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"IBM Plex Mono\", monospace",
+            "contagem": 41
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 32,
+          "tag": "h2",
+          "className": "",
+          "caracteres": 5,
+          "palavras": 1,
+          "fontFamily": "\"IBM Plex Mono\", monospace",
+          "familiaEfetiva": "IBM Plex Mono",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "500",
+          "textTransform": "uppercase",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 16.5
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://incomescrane.com"
+    },
+    "incomescrane@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:26:23.692Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 4275,
+        "imgs": 8,
+        "carregadas": 7
+      },
+      "data": {
+        "url": "https://incomescrane.com/",
+        "altura": 4275,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 28
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 4.2,
+        "telas_base900_legado": 4.8,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0.002,
+        "cromaPicoOklch": 0.003,
+        "fundos": [
+          {
+            "cor": "rgb(219,218,216)",
+            "pct": 52.6,
+            "L": 0.89,
+            "C": 0.003,
+            "H": 85
+          },
+          {
+            "cor": "rgb(239,239,239)",
+            "pct": 47.4,
+            "L": 0.95,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 0,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 8,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 1.87,
+        "keyframes": 2,
+        "nomes": [
+          "fadeInOut-1",
+          "fadeInOut-2"
+        ],
+        "keyframesPor1000": 0.47,
+        "folhasBloqueadas": 1,
+        "emTransicao": 2,
+        "emTransicaoPor1000": 0.47,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.3s",
+            2
+          ]
+        ],
+        "tamTitulos": [
+          32
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 35
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 32,
+            "elementos": 4,
+            "caracteres": 25,
+            "palavras": 4,
+            "textos": [
+              "ABOUT",
+              "PROJECTS",
+              "MEDIA",
+              "CONTACT"
+            ],
+            "fontFamily": "\"IBM Plex Mono\", monospace",
+            "familiaEfetiva": "IBM Plex Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ibm plex mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "500",
+            "lineHeightPx": "35.2px",
+            "lineHeightRazao": 1.1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 31,
+            "maiorLarguraCh": 31,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"IBM Plex Mono\", monospace",
+          "familiaEfetiva": "IBM Plex Mono",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "16px",
+          "lineHeightRazao": 1,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 62
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            68,
+            32
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 35
+          },
+          "razao_semFiltro": 4.25,
+          "divergeDoCorrigido": true
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 68,
+              "motivo": "display:none",
+              "texto": "portfolio"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 4,
+          "caracteresTotais": 25,
+          "caracteresPor1000px": 5.85,
+          "semNeutralizar": 4,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"IBM Plex Mono\", monospace",
+            "contagem": 41
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 32,
+          "tag": "h2",
+          "className": "",
+          "caracteres": 5,
+          "palavras": 1,
+          "fontFamily": "\"IBM Plex Mono\", monospace",
+          "familiaEfetiva": "IBM Plex Mono",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "500",
+          "textTransform": "uppercase",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 17
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            32
+          ],
+          "maiorTexto": 32
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://incomescrane.com"
+    },
+    "shelomoh@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:26:34.774Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 2047,
+        "imgs": 4,
+        "carregadas": 4
+      },
+      "data": {
+        "url": "https://shelomoh.work/",
+        "altura": 2047,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 56
+        },
+        "viewportMedido": {
+          "w": 320,
+          "h": 568,
+          "dpr": 2
+        },
+        "telas": 3.6,
+        "telas_base900_legado": 2.3,
+        "metricaV2_hsvS015": 3.8,
+        "corPerceptivel_C005": 3.8,
+        "corForte_C012": 3.8,
+        "cromaMedioPonderado": 0.014,
+        "cromaPicoOklch": 0.291,
+        "fundos": [
+          {
+            "cor": "rgb(29,29,31)",
+            "pct": 53.5,
+            "L": 0.23,
+            "C": 0.004,
+            "H": 286
+          },
+          {
+            "cor": "rgb(250,250,252)",
+            "pct": 42.7,
+            "L": 0.99,
+            "C": 0.003,
+            "H": 286
+          },
+          {
+            "cor": "rgb(0,39,247)",
+            "pct": 3.8,
+            "L": 0.46,
+            "C": 0.291,
+            "H": 264
+          }
+        ],
+        "midia": {
+          "img": 4,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 1.95,
+        "keyframes": 6,
+        "nomes": [
+          "marquee",
+          "marquee",
+          "rotation",
+          "rotation",
+          "spin",
+          "bounce"
+        ],
+        "keyframesPor1000": 2.93,
+        "folhasBloqueadas": 2,
+        "emTransicao": 201,
+        "emTransicaoPor1000": 98.19,
+        "animacoesAtivas": 3,
+        "duracoes": [
+          [
+            "0.2s",
+            194
+          ],
+          [
+            "0.3s",
+            10
+          ],
+          [
+            "1s",
+            1
+          ],
+          [
+            "0.5s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          30,
+          20
+        ],
+        "workhorse": null,
+        "razaoTituloWorkhorse": null,
+        "titulosDetalhes": [
+          {
+            "px": 30,
+            "elementos": 1,
+            "caracteres": 42,
+            "palavras": 5,
+            "textos": [
+              "FULL-STACK DEVELOPER AND HOBBYIST DESIGNER"
+            ],
+            "fontFamily": "Manrope",
+            "familiaEfetiva": "Manrope",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "manrope",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "36px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 15,
+            "maiorLarguraCh": 15,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 20,
+            "elementos": 2,
+            "caracteres": 196,
+            "palavras": 30,
+            "textos": [
+              "Passionate about innovation and tackling new challenges through both technical and creative solutions.",
+              "Come say hello! 👋\nLINKEDIN\nGITHUB\nINSTAGRAM\nor if you feeling old fashioned, send me an email"
+            ],
+            "fontFamily": "Manrope",
+            "familiaEfetiva": "Manrope",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "manrope",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "28px",
+            "lineHeightRazao": 1.4,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 24,
+            "maiorLarguraCh": 24,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": null,
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            30,
+            20
+          ],
+          "workhorse_semFiltro": null,
+          "razao_semFiltro": null,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 54,
+          "caracteresTotais": 969,
+          "caracteresPor1000px": 473.38,
+          "semNeutralizar": 54,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Manrope",
+            "contagem": 3
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 80,
+          "tag": "span",
+          "className": "absolute\n                                w-full h-full\n                                flex justify-center items-center\n                                group-hover:invert\n                                group-hover:animate-bounce\n                                font-['Inter']\n                                font-light\n                                text-red text-center text-[80px]",
+          "caracteres": 1,
+          "palavras": 1,
+          "fontFamily": "Inter",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "300",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 20.9
+        },
+        "pontoCego": true,
+        "diferencaPx": 50,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            30,
+            20
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            30,
+            20
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            30,
+            20
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            30,
+            20
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            30,
+            20
+          ],
+          "maiorTexto": 80
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://shelomoh.work"
+    },
+    "shelomoh@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:26:45.338Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 2234,
+        "imgs": 4,
+        "carregadas": 4
+      },
+      "data": {
+        "url": "https://shelomoh.work/",
+        "altura": 2234,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 56
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 2.6,
+        "telas_base900_legado": 2.5,
+        "metricaV2_hsvS015": 3.5,
+        "corPerceptivel_C005": 3.5,
+        "corForte_C012": 3.5,
+        "cromaMedioPonderado": 0.013,
+        "cromaPicoOklch": 0.291,
+        "fundos": [
+          {
+            "cor": "rgb(29,29,31)",
+            "pct": 52.8,
+            "L": 0.23,
+            "C": 0.004,
+            "H": 286
+          },
+          {
+            "cor": "rgb(251,251,253)",
+            "pct": 43.7,
+            "L": 0.99,
+            "C": 0.003,
+            "H": 286
+          },
+          {
+            "cor": "rgb(0,39,247)",
+            "pct": 3.5,
+            "L": 0.46,
+            "C": 0.291,
+            "H": 264
+          }
+        ],
+        "midia": {
+          "img": 4,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 1.79,
+        "keyframes": 6,
+        "nomes": [
+          "marquee",
+          "marquee",
+          "rotation",
+          "rotation",
+          "spin",
+          "bounce"
+        ],
+        "keyframesPor1000": 2.69,
+        "folhasBloqueadas": 2,
+        "emTransicao": 201,
+        "emTransicaoPor1000": 89.97,
+        "animacoesAtivas": 3,
+        "duracoes": [
+          [
+            "0.2s",
+            194
+          ],
+          [
+            "0.3s",
+            10
+          ],
+          [
+            "1s",
+            1
+          ],
+          [
+            "0.5s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          30,
+          20
+        ],
+        "workhorse": null,
+        "razaoTituloWorkhorse": null,
+        "titulosDetalhes": [
+          {
+            "px": 30,
+            "elementos": 1,
+            "caracteres": 42,
+            "palavras": 5,
+            "textos": [
+              "FULL-STACK DEVELOPER AND HOBBYIST DESIGNER"
+            ],
+            "fontFamily": "Manrope",
+            "familiaEfetiva": "Manrope",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "manrope",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "36px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 18,
+            "maiorLarguraCh": 18,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 20,
+            "elementos": 2,
+            "caracteres": 196,
+            "palavras": 30,
+            "textos": [
+              "Passionate about innovation and tackling new challenges through both technical and creative solutions.",
+              "Come say hello! 👋\nLINKEDIN\nGITHUB\nINSTAGRAM\nor if you feeling old fashioned, send me an email"
+            ],
+            "fontFamily": "Manrope",
+            "familiaEfetiva": "Manrope",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "manrope",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "28px",
+            "lineHeightRazao": 1.4,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 29,
+            "maiorLarguraCh": 29,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": null,
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            30,
+            20
+          ],
+          "workhorse_semFiltro": null,
+          "razao_semFiltro": null,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 54,
+          "caracteresTotais": 969,
+          "caracteresPor1000px": 433.75,
+          "semNeutralizar": 54,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Manrope",
+            "contagem": 3
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 80,
+          "tag": "span",
+          "className": "absolute\n                                w-full h-full\n                                flex justify-center items-center\n                                group-hover:invert\n                                group-hover:animate-bounce\n                                font-['Inter']\n                                font-light\n                                text-red text-center text-[80px]",
+          "caracteres": 1,
+          "palavras": 1,
+          "fontFamily": "Inter",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "300",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 23.3
+        },
+        "pontoCego": true,
+        "diferencaPx": 50,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            30,
+            20
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            30,
+            20
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            30,
+            20
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            30,
+            20
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            30,
+            20
+          ],
+          "maiorTexto": 80
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://shelomoh.work"
+    },
+    "shelomoh@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:26:55.922Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 2496,
+        "imgs": 4,
+        "carregadas": 4
+      },
+      "data": {
+        "url": "https://shelomoh.work/",
+        "altura": 2496,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 56
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 2.4,
+        "telas_base900_legado": 2.8,
+        "metricaV2_hsvS015": 3.1,
+        "corPerceptivel_C005": 3.1,
+        "corForte_C012": 3.1,
+        "cromaMedioPonderado": 0.012,
+        "cromaPicoOklch": 0.291,
+        "fundos": [
+          {
+            "cor": "rgb(29,29,31)",
+            "pct": 52.2,
+            "L": 0.23,
+            "C": 0.004,
+            "H": 286
+          },
+          {
+            "cor": "rgb(189,189,191)",
+            "pct": 44.7,
+            "L": 0.8,
+            "C": 0.003,
+            "H": 286
+          },
+          {
+            "cor": "rgb(0,39,247)",
+            "pct": 3.1,
+            "L": 0.46,
+            "C": 0.291,
+            "H": 264
+          }
+        ],
+        "midia": {
+          "img": 4,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 1.6,
+        "keyframes": 6,
+        "nomes": [
+          "marquee",
+          "marquee",
+          "rotation",
+          "rotation",
+          "spin",
+          "bounce"
+        ],
+        "keyframesPor1000": 2.4,
+        "folhasBloqueadas": 2,
+        "emTransicao": 201,
+        "emTransicaoPor1000": 80.53,
+        "animacoesAtivas": 3,
+        "duracoes": [
+          [
+            "0.2s",
+            194
+          ],
+          [
+            "0.3s",
+            10
+          ],
+          [
+            "1s",
+            1
+          ],
+          [
+            "0.5s",
+            1
+          ]
+        ],
+        "tamTitulos": [
+          60,
+          36,
+          30
+        ],
+        "workhorse": null,
+        "razaoTituloWorkhorse": null,
+        "titulosDetalhes": [
+          {
+            "px": 60,
+            "elementos": 1,
+            "caracteres": 42,
+            "palavras": 5,
+            "textos": [
+              "FULL-STACK DEVELOPER AND HOBBYIST DESIGNER"
+            ],
+            "fontFamily": "Manrope",
+            "familiaEfetiva": "Manrope",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "manrope",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "60px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 19,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 36,
+            "elementos": 1,
+            "caracteres": 7,
+            "palavras": 1,
+            "textos": [
+              "CREDITS"
+            ],
+            "fontFamily": "Manrope",
+            "familiaEfetiva": "Manrope",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "manrope",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "40px",
+            "lineHeightRazao": 1.11,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 31,
+            "maiorLarguraCh": 31,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 30,
+            "elementos": 2,
+            "caracteres": 196,
+            "palavras": 30,
+            "textos": [
+              "Passionate about innovation and tackling new challenges through both technical and creative solutions.",
+              "Come say hello! 👋\nLINKEDIN\nGITHUB\nINSTAGRAM\nor if you feeling old fashioned, send me an email"
+            ],
+            "fontFamily": "Manrope",
+            "familiaEfetiva": "Manrope",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "manrope",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "36px",
+            "lineHeightRazao": 1.2,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 27,
+            "maiorLarguraCh": 40,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": null,
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            60,
+            36,
+            30
+          ],
+          "workhorse_semFiltro": null,
+          "razao_semFiltro": null,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 56,
+          "caracteresTotais": 1001,
+          "caracteresPor1000px": 401.04,
+          "semNeutralizar": 56,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Manrope",
+            "contagem": 4
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 80,
+          "tag": "span",
+          "className": "absolute\n                                w-full h-full\n                                flex justify-center items-center\n                                group-hover:invert\n                                group-hover:animate-bounce\n                                font-['Inter']\n                                font-light\n                                text-red text-center text-[80px]",
+          "caracteres": 1,
+          "palavras": 1,
+          "fontFamily": "Inter",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "300",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 25.4
+        },
+        "pontoCego": true,
+        "diferencaPx": 20,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            60,
+            36,
+            30
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            60,
+            36,
+            30
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            60,
+            36,
+            30
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            60,
+            36,
+            30
+          ],
+          "maiorTexto": 80
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            60,
+            36,
+            30
+          ],
+          "maiorTexto": 80
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://shelomoh.work"
+    },
+    "thatmlopsguy@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:27:07.172Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 6252,
+        "imgs": 5,
+        "carregadas": 5
+      },
+      "data": {
+        "url": "https://thatmlopsguy.github.io/",
+        "altura": 6252,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 572,
+          "h": 1016,
+          "dpr": 2
+        },
+        "telas": 6.2,
+        "telas_base900_legado": 6.9,
+        "metricaV2_hsvS015": 100,
+        "corPerceptivel_C005": 0.7,
+        "corForte_C012": 0.7,
+        "cromaMedioPonderado": 0.029,
+        "cromaPicoOklch": 0.215,
+        "fundos": [
+          {
+            "cor": "rgb(10,15,26)",
+            "pct": 79.4,
+            "L": 0.17,
+            "C": 0.025,
+            "H": 265
+          },
+          {
+            "cor": "rgb(15,23,42)",
+            "pct": 19.5,
+            "L": 0.21,
+            "C": 0.04,
+            "H": 266
+          },
+          {
+            "cor": "rgb(37,99,235)",
+            "pct": 0.7,
+            "L": 0.55,
+            "C": 0.215,
+            "H": 263
+          },
+          {
+            "cor": "rgb(30,41,59)",
+            "pct": 0.4,
+            "L": 0.28,
+            "C": 0.037,
+            "H": 260
+          }
+        ],
+        "midia": {
+          "img": 5,
+          "svg": 1,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 0.96,
+        "keyframes": 2,
+        "nomes": [
+          "pulse",
+          "fadeIn"
+        ],
+        "keyframesPor1000": 0.32,
+        "folhasBloqueadas": 0,
+        "emTransicao": 33,
+        "emTransicaoPor1000": 5.28,
+        "animacoesAtivas": 7,
+        "duracoes": [
+          [
+            "0.2s",
+            25
+          ],
+          [
+            "0.3s",
+            18
+          ]
+        ],
+        "tamTitulos": [
+          40,
+          32,
+          19,
+          18
+        ],
+        "workhorse": {
+          "px": 14,
+          "ocorrencias": 12
+        },
+        "razaoTituloWorkhorse": 2.86,
+        "titulosDetalhes": [
+          {
+            "px": 40,
+            "elementos": 1,
+            "caracteres": 25,
+            "palavras": 4,
+            "textos": [
+              "MLOps\n& DevOps Excellence"
+            ],
+            "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "familiaEfetiva": "system-ui",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "system-ui",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "800",
+            "lineHeightPx": "44px",
+            "lineHeightRazao": 1.1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1.2px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 13,
+            "maiorLarguraCh": 13,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 32,
+            "elementos": 4,
+            "caracteres": 76,
+            "palavras": 11,
+            "textos": [
+              "Featured Work",
+              "Featured Projects",
+              "Latest Insights",
+              "Ready to build something great?"
+            ],
+            "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "familiaEfetiva": "system-ui",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "system-ui",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "54.4px",
+            "lineHeightRazao": 1.7,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.64px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 16,
+            "maiorLarguraCh": 16,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 19,
+            "elementos": 7,
+            "caracteres": 267,
+            "palavras": 34,
+            "textos": [
+              "doKa seca",
+              "github-k8s-operator",
+              "k8sResourceResizer",
+              "helm-charts",
+              "Bridging the Gap: Implementing GitOps Bridge Pattern with Kind",
+              "Introducing Future Perspectives: A new initiative to update our world view"
+            ],
+            "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "familiaEfetiva": "system-ui",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "system-ui",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "32.64px",
+            "lineHeightRazao": 1.72,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.192px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 21,
+            "maiorLarguraCh": 21,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 5,
+            "caracteres": 86,
+            "palavras": 11,
+            "textos": [
+              "Telecommunications",
+              "E-Commerce & Logistics",
+              "Marine Robotics",
+              "Research",
+              "Industrial IoT & Energy"
+            ],
+            "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "familiaEfetiva": "system-ui",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "system-ui",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "29.92px",
+            "lineHeightRazao": 1.66,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 17,
+            "maiorLarguraCh": 17,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 14,
+          "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+          "familiaEfetiva": "system-ui",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "21.6px",
+          "lineHeightRazao": 1.54,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 29
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            40,
+            32,
+            19,
+            18
+          ],
+          "workhorse_semFiltro": {
+            "px": 14,
+            "ocorrencias": 12
+          },
+          "razao_semFiltro": 2.86,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 8,
+          "caracteresTotais": 92,
+          "caracteresPor1000px": 14.72,
+          "semNeutralizar": 8,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "contagem": 36
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 40,
+          "tag": "h1",
+          "className": "hero-title animate-fade-in",
+          "caracteres": 5,
+          "palavras": 1,
+          "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+          "familiaEfetiva": "system-ui",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "800",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 3.3
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            40,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 40
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            40,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 40
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            40,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 40
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            40,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 40
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            40,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 40
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://thatmlopsguy.github.io"
+    },
+    "thatmlopsguy@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:27:17.793Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 5899,
+        "imgs": 5,
+        "carregadas": 5
+      },
+      "data": {
+        "url": "https://thatmlopsguy.github.io/",
+        "altura": 5899,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 572,
+          "h": 1238,
+          "dpr": 2
+        },
+        "telas": 4.8,
+        "telas_base900_legado": 6.6,
+        "metricaV2_hsvS015": 100,
+        "corPerceptivel_C005": 0.6,
+        "corForte_C012": 0.6,
+        "cromaMedioPonderado": 0.029,
+        "cromaPicoOklch": 0.215,
+        "fundos": [
+          {
+            "cor": "rgb(10,15,26)",
+            "pct": 78.9,
+            "L": 0.17,
+            "C": 0.025,
+            "H": 265
+          },
+          {
+            "cor": "rgb(15,23,42)",
+            "pct": 20.1,
+            "L": 0.21,
+            "C": 0.04,
+            "H": 266
+          },
+          {
+            "cor": "rgb(37,99,235)",
+            "pct": 0.6,
+            "L": 0.55,
+            "C": 0.215,
+            "H": 263
+          },
+          {
+            "cor": "rgb(30,41,59)",
+            "pct": 0.3,
+            "L": 0.28,
+            "C": 0.037,
+            "H": 260
+          }
+        ],
+        "midia": {
+          "img": 5,
+          "svg": 1,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 1.02,
+        "keyframes": 2,
+        "nomes": [
+          "pulse",
+          "fadeIn"
+        ],
+        "keyframesPor1000": 0.34,
+        "folhasBloqueadas": 0,
+        "emTransicao": 33,
+        "emTransicaoPor1000": 5.59,
+        "animacoesAtivas": 7,
+        "duracoes": [
+          [
+            "0.2s",
+            25
+          ],
+          [
+            "0.3s",
+            18
+          ]
+        ],
+        "tamTitulos": [
+          40,
+          32,
+          19,
+          18
+        ],
+        "workhorse": {
+          "px": 14,
+          "ocorrencias": 12
+        },
+        "razaoTituloWorkhorse": 2.86,
+        "titulosDetalhes": [
+          {
+            "px": 40,
+            "elementos": 1,
+            "caracteres": 25,
+            "palavras": 4,
+            "textos": [
+              "MLOps\n& DevOps Excellence"
+            ],
+            "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "familiaEfetiva": "system-ui",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "system-ui",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "800",
+            "lineHeightPx": "44px",
+            "lineHeightRazao": 1.1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1.2px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 14,
+            "maiorLarguraCh": 14,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 32,
+            "elementos": 4,
+            "caracteres": 76,
+            "palavras": 11,
+            "textos": [
+              "Featured Work",
+              "Featured Projects",
+              "Latest Insights",
+              "Ready to build something great?"
+            ],
+            "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "familiaEfetiva": "system-ui",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "system-ui",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "54.4px",
+            "lineHeightRazao": 1.7,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.64px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 20,
+            "maiorLarguraCh": 20,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 19,
+            "elementos": 7,
+            "caracteres": 267,
+            "palavras": 34,
+            "textos": [
+              "doKa seca",
+              "github-k8s-operator",
+              "k8sResourceResizer",
+              "helm-charts",
+              "Bridging the Gap: Implementing GitOps Bridge Pattern with Kind",
+              "Introducing Future Perspectives: A new initiative to update our world view"
+            ],
+            "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "familiaEfetiva": "system-ui",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "system-ui",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "32.64px",
+            "lineHeightRazao": 1.72,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.192px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 28,
+            "maiorLarguraCh": 28,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 5,
+            "caracteres": 86,
+            "palavras": 11,
+            "textos": [
+              "Telecommunications",
+              "E-Commerce & Logistics",
+              "Marine Robotics",
+              "Research",
+              "Industrial IoT & Energy"
+            ],
+            "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "familiaEfetiva": "system-ui",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "system-ui",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "29.92px",
+            "lineHeightRazao": 1.66,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 17,
+            "maiorLarguraCh": 17,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 14,
+          "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+          "familiaEfetiva": "system-ui",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "21.6px",
+          "lineHeightRazao": 1.54,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 38
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            40,
+            32,
+            19,
+            18
+          ],
+          "workhorse_semFiltro": {
+            "px": 14,
+            "ocorrencias": 12
+          },
+          "razao_semFiltro": 2.86,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 8,
+          "caracteresTotais": 92,
+          "caracteresPor1000px": 15.6,
+          "semNeutralizar": 8,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "contagem": 36
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 40,
+          "tag": "h1",
+          "className": "hero-title animate-fade-in",
+          "caracteres": 5,
+          "palavras": 1,
+          "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+          "familiaEfetiva": "system-ui",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "800",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 3.5
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            40,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 40
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            40,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 40
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            40,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 40
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            40,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 40
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            40,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 40
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://thatmlopsguy.github.io"
+    },
+    "thatmlopsguy@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:27:28.279Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 4972,
+        "imgs": 5,
+        "carregadas": 5
+      },
+      "data": {
+        "url": "https://thatmlopsguy.github.io/",
+        "altura": 4972,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 4.9,
+        "telas_base900_legado": 5.5,
+        "metricaV2_hsvS015": 100,
+        "corPerceptivel_C005": 0.4,
+        "corForte_C012": 0.4,
+        "cromaMedioPonderado": 0.029,
+        "cromaPicoOklch": 0.215,
+        "fundos": [
+          {
+            "cor": "rgb(10,15,26)",
+            "pct": 77.7,
+            "L": 0.17,
+            "C": 0.025,
+            "H": 265
+          },
+          {
+            "cor": "rgb(15,23,42)",
+            "pct": 21.7,
+            "L": 0.21,
+            "C": 0.04,
+            "H": 266
+          },
+          {
+            "cor": "rgb(37,99,235)",
+            "pct": 0.4,
+            "L": 0.55,
+            "C": 0.215,
+            "H": 263
+          },
+          {
+            "cor": "rgb(30,41,59)",
+            "pct": 0.2,
+            "L": 0.28,
+            "C": 0.037,
+            "H": 260
+          }
+        ],
+        "midia": {
+          "img": 5,
+          "svg": 1,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 1.21,
+        "keyframes": 2,
+        "nomes": [
+          "pulse",
+          "fadeIn"
+        ],
+        "keyframesPor1000": 0.4,
+        "folhasBloqueadas": 0,
+        "emTransicao": 33,
+        "emTransicaoPor1000": 6.64,
+        "animacoesAtivas": 7,
+        "duracoes": [
+          [
+            "0.2s",
+            25
+          ],
+          [
+            "0.3s",
+            18
+          ]
+        ],
+        "tamTitulos": [
+          56,
+          32,
+          19,
+          18
+        ],
+        "workhorse": {
+          "px": 14,
+          "ocorrencias": 12
+        },
+        "razaoTituloWorkhorse": 4,
+        "titulosDetalhes": [
+          {
+            "px": 56,
+            "elementos": 1,
+            "caracteres": 25,
+            "palavras": 4,
+            "textos": [
+              "MLOps\n& DevOps Excellence"
+            ],
+            "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "familiaEfetiva": "system-ui",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "system-ui",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "800",
+            "lineHeightPx": "61.6px",
+            "lineHeightRazao": 1.1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1.68px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 17,
+            "maiorLarguraCh": 17,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 32,
+            "elementos": 4,
+            "caracteres": 76,
+            "palavras": 11,
+            "textos": [
+              "Featured Work",
+              "Featured Projects",
+              "Latest Insights",
+              "Ready to build something great?"
+            ],
+            "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "familiaEfetiva": "system-ui",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "system-ui",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "54.4px",
+            "lineHeightRazao": 1.7,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.64px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 41,
+            "maiorLarguraCh": 41,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 19,
+            "elementos": 7,
+            "caracteres": 267,
+            "palavras": 34,
+            "textos": [
+              "doKa seca",
+              "github-k8s-operator",
+              "k8sResourceResizer",
+              "helm-charts",
+              "Bridging the Gap: Implementing GitOps Bridge Pattern with Kind",
+              "Introducing Future Perspectives: A new initiative to update our world view"
+            ],
+            "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "familiaEfetiva": "system-ui",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "system-ui",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "32.64px",
+            "lineHeightRazao": 1.72,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.192px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 64,
+            "maiorLarguraCh": 64,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 5,
+            "caracteres": 86,
+            "palavras": 11,
+            "textos": [
+              "Telecommunications",
+              "E-Commerce & Logistics",
+              "Marine Robotics",
+              "Research",
+              "Industrial IoT & Energy"
+            ],
+            "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "familiaEfetiva": "system-ui",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "system-ui",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "29.92px",
+            "lineHeightRazao": 1.66,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 29,
+            "maiorLarguraCh": 29,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 14,
+          "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+          "familiaEfetiva": "system-ui",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "21.6px",
+          "lineHeightRazao": 1.54,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 86
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            56,
+            32,
+            19,
+            18
+          ],
+          "workhorse_semFiltro": {
+            "px": 14,
+            "ocorrencias": 12
+          },
+          "razao_semFiltro": 4,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 8,
+          "caracteresTotais": 92,
+          "caracteresPor1000px": 18.5,
+          "semNeutralizar": 8,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+            "contagem": 36
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 56,
+          "tag": "h1",
+          "className": "hero-title animate-fade-in",
+          "caracteres": 5,
+          "palavras": 1,
+          "fontFamily": "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif",
+          "familiaEfetiva": "system-ui",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "800",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 4.1
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            56,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 56
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            56,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 56
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            56,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 56
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            56,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 56
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            56,
+            32,
+            19,
+            18
+          ],
+          "maiorTexto": 56
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://thatmlopsguy.github.io"
+    },
+    "cassidoo@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:27:39.099Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 2823,
+        "imgs": 1,
+        "carregadas": 1
+      },
+      "data": {
+        "url": "https://cassidoo.co/",
+        "altura": 2823,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 4
+        },
+        "viewportMedido": {
+          "w": 320,
+          "h": 568,
+          "dpr": 2
+        },
+        "telas": 5,
+        "telas_base900_legado": 3.1,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(37,37,37)",
+            "pct": 100,
+            "L": 0.26,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 1,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 0.35,
+        "keyframes": 1,
+        "nomes": [
+          "dialog-fade-in"
+        ],
+        "keyframesPor1000": 0.35,
+        "folhasBloqueadas": 0,
+        "emTransicao": 0,
+        "emTransicaoPor1000": 0,
+        "animacoesAtivas": 0,
+        "duracoes": [],
+        "tamTitulos": [
+          32,
+          24,
+          19
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 9
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 32,
+            "elementos": 1,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "Cassidy Williams"
+            ],
+            "fontFamily": "\"iA Writer Mono\", monospace",
+            "familiaEfetiva": "iA Writer Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ia writer mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "normal",
+            "lineHeightRazao": 1.31,
+            "lineHeightOrigem": "normal-medida",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 12,
+            "maiorLarguraCh": 12,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 24,
+            "elementos": 1,
+            "caracteres": 28,
+            "palavras": 4,
+            "textos": [
+              "Software Engineer in Chicago"
+            ],
+            "fontFamily": "\"iA Writer Mono\", monospace",
+            "familiaEfetiva": "iA Writer Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ia writer mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "26.4px",
+            "lineHeightRazao": 1.1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 17,
+            "maiorLarguraCh": 17,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 19,
+            "elementos": 2,
+            "caracteres": 66,
+            "palavras": 14,
+            "textos": [
+              "Here's my most recent posts or read a random one!",
+              "View posts by tag"
+            ],
+            "fontFamily": "\"iA Writer Mono\", monospace",
+            "familiaEfetiva": "iA Writer Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ia writer mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "20.592px",
+            "lineHeightRazao": 1.08,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 21,
+            "maiorLarguraCh": 21,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"iA Writer Mono\", monospace",
+          "familiaEfetiva": "iA Writer Mono",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "25.6px",
+          "lineHeightRazao": 1.6,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 25
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            32,
+            24,
+            19
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 9
+          },
+          "razao_semFiltro": 2,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"iA Writer Mono\", monospace",
+            "contagem": 13
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 32,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 16,
+          "palavras": 2,
+          "fontFamily": "\"iA Writer Mono\", monospace",
+          "familiaEfetiva": "iA Writer Mono",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "400",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 2.2
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://cassidoo.co"
+    },
+    "cassidoo@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:27:49.539Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 2435,
+        "imgs": 1,
+        "carregadas": 1
+      },
+      "data": {
+        "url": "https://cassidoo.co/",
+        "altura": 2435,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 4
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 2.9,
+        "telas_base900_legado": 2.7,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(37,37,37)",
+            "pct": 100,
+            "L": 0.26,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 1,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 0.41,
+        "keyframes": 1,
+        "nomes": [
+          "dialog-fade-in"
+        ],
+        "keyframesPor1000": 0.41,
+        "folhasBloqueadas": 0,
+        "emTransicao": 0,
+        "emTransicaoPor1000": 0,
+        "animacoesAtivas": 0,
+        "duracoes": [],
+        "tamTitulos": [
+          32,
+          24,
+          19
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 9
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 32,
+            "elementos": 1,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "Cassidy Williams"
+            ],
+            "fontFamily": "\"iA Writer Mono\", monospace",
+            "familiaEfetiva": "iA Writer Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ia writer mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "normal",
+            "lineHeightRazao": 1.31,
+            "lineHeightOrigem": "normal-medida",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 16,
+            "maiorLarguraCh": 16,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 24,
+            "elementos": 1,
+            "caracteres": 28,
+            "palavras": 4,
+            "textos": [
+              "Software Engineer in Chicago"
+            ],
+            "fontFamily": "\"iA Writer Mono\", monospace",
+            "familiaEfetiva": "iA Writer Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ia writer mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "26.4px",
+            "lineHeightRazao": 1.1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 22,
+            "maiorLarguraCh": 22,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 19,
+            "elementos": 2,
+            "caracteres": 66,
+            "palavras": 14,
+            "textos": [
+              "Here's my most recent posts or read a random one!",
+              "View posts by tag"
+            ],
+            "fontFamily": "\"iA Writer Mono\", monospace",
+            "familiaEfetiva": "iA Writer Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ia writer mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "20.592px",
+            "lineHeightRazao": 1.08,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 28,
+            "maiorLarguraCh": 28,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"iA Writer Mono\", monospace",
+          "familiaEfetiva": "iA Writer Mono",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "25.6px",
+          "lineHeightRazao": 1.6,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 32
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            32,
+            24,
+            19
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 9
+          },
+          "razao_semFiltro": 2,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"iA Writer Mono\", monospace",
+            "contagem": 13
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 32,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 16,
+          "palavras": 2,
+          "fontFamily": "\"iA Writer Mono\", monospace",
+          "familiaEfetiva": "iA Writer Mono",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "400",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 2.5
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://cassidoo.co"
+    },
+    "cassidoo@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:27:59.691Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 1654,
+        "imgs": 1,
+        "carregadas": 1
+      },
+      "data": {
+        "url": "https://cassidoo.co/",
+        "altura": 1654,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 4
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 1.6,
+        "telas_base900_legado": 1.8,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(37,37,37)",
+            "pct": 100,
+            "L": 0.26,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 1,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 0.6,
+        "keyframes": 1,
+        "nomes": [
+          "dialog-fade-in"
+        ],
+        "keyframesPor1000": 0.6,
+        "folhasBloqueadas": 0,
+        "emTransicao": 0,
+        "emTransicaoPor1000": 0,
+        "animacoesAtivas": 0,
+        "duracoes": [],
+        "tamTitulos": [
+          32,
+          24,
+          19
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 9
+        },
+        "razaoTituloWorkhorse": 2,
+        "titulosDetalhes": [
+          {
+            "px": 32,
+            "elementos": 1,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "Cassidy Williams"
+            ],
+            "fontFamily": "\"iA Writer Mono\", monospace",
+            "familiaEfetiva": "iA Writer Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ia writer mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "normal",
+            "lineHeightRazao": 1.31,
+            "lineHeightOrigem": "normal-medida",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 18,
+            "maiorLarguraCh": 18,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 24,
+            "elementos": 1,
+            "caracteres": 28,
+            "palavras": 4,
+            "textos": [
+              "Software Engineer in Chicago"
+            ],
+            "fontFamily": "\"iA Writer Mono\", monospace",
+            "familiaEfetiva": "iA Writer Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ia writer mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "400",
+            "lineHeightPx": "26.4px",
+            "lineHeightRazao": 1.1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 24,
+            "maiorLarguraCh": 24,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 19,
+            "elementos": 2,
+            "caracteres": 66,
+            "palavras": 14,
+            "textos": [
+              "Here's my most recent posts or read a random one!",
+              "View posts by tag"
+            ],
+            "fontFamily": "\"iA Writer Mono\", monospace",
+            "familiaEfetiva": "iA Writer Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ia writer mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "20.592px",
+            "lineHeightRazao": 1.08,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 56,
+            "maiorLarguraCh": 56,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "\"iA Writer Mono\", monospace",
+          "familiaEfetiva": "iA Writer Mono",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "25.6px",
+          "lineHeightRazao": 1.6,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 66
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            32,
+            24,
+            19
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 9
+          },
+          "razao_semFiltro": 2,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "\"iA Writer Mono\", monospace",
+            "contagem": 13
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 32,
+          "tag": "h1",
+          "className": "",
+          "caracteres": 16,
+          "palavras": 2,
+          "fontFamily": "\"iA Writer Mono\", monospace",
+          "familiaEfetiva": "iA Writer Mono",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "400",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 5.8
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            32,
+            24,
+            19
+          ],
+          "maiorTexto": 32
+        }
+      ],
+      "rotulo": "rejeitado",
+      "url": "https://cassidoo.co"
+    },
+    "ciere@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:28:11.660Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 11139,
+        "imgs": 9,
+        "carregadas": 8
+      },
+      "data": {
+        "url": "https://advocaciacieredarosa.com.br/",
+        "altura": 11139,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 35
+        },
+        "viewportMedido": {
+          "w": 320,
+          "h": 568,
+          "dpr": 2
+        },
+        "telas": 19.6,
+        "telas_base900_legado": 12.4,
+        "metricaV2_hsvS015": 26.7,
+        "corPerceptivel_C005": 26.7,
+        "corForte_C012": 0.3,
+        "cromaMedioPonderado": 0.03,
+        "cromaPicoOklch": 0.145,
+        "fundos": [
+          {
+            "cor": "rgb(243,236,220)",
+            "pct": 58.1,
+            "L": 0.94,
+            "C": 0.023,
+            "H": 87
+          },
+          {
+            "cor": "rgb(77,54,28)",
+            "pct": 26.4,
+            "L": 0.35,
+            "C": 0.051,
+            "H": 68
+          },
+          {
+            "cor": "rgb(233,226,208)",
+            "pct": 10.1,
+            "L": 0.91,
+            "C": 0.025,
+            "H": 89
+          },
+          {
+            "cor": "rgb(255,253,248)",
+            "pct": 5.1,
+            "L": 0.99,
+            "C": 0.007,
+            "H": 89
+          },
+          {
+            "cor": "rgb(206,145,0)",
+            "pct": 0.3,
+            "L": 0.7,
+            "C": 0.145,
+            "H": 79
+          }
+        ],
+        "midia": {
+          "img": 9,
+          "svg": 10,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 1.71,
+        "keyframes": 3,
+        "nomes": [
+          "marquee",
+          "hero-in-left",
+          "hero-in-right"
+        ],
+        "keyframesPor1000": 0.27,
+        "folhasBloqueadas": 1,
+        "emTransicao": 28,
+        "emTransicaoPor1000": 2.51,
+        "animacoesAtivas": 1,
+        "duracoes": [
+          [
+            "0.15s",
+            18
+          ],
+          [
+            "0.3s",
+            10
+          ]
+        ],
+        "tamTitulos": [
+          32,
+          30,
+          18,
+          16,
+          12
+        ],
+        "workhorse": {
+          "px": 14,
+          "ocorrencias": 17
+        },
+        "razaoTituloWorkhorse": 2.29,
+        "titulosDetalhes": [
+          {
+            "px": 32,
+            "elementos": 6,
+            "caracteres": 290,
+            "palavras": 50,
+            "textos": [
+              "Suporte jurídico para os momentos que exigem mais cuidado",
+              "O que você encontra no meu processo",
+              "Uma advogada que entende que, por trás de cada processo, existe uma história de vida.",
+              "Quem já foi atendido, recomenda.",
+              "Perguntas que ouço com frequência",
+              "Dê o primeiro passo com quem entende seu momento"
+            ],
+            "fontFamily": "\"Cormorant Garamond\", serif",
+            "familiaEfetiva": "Cormorant Garamond",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cormorant garamond",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "600",
+            "lineHeightPx": "36.8px",
+            "lineHeightRazao": 1.15,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 15,
+            "maiorLarguraCh": 18,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 30,
+            "elementos": 1,
+            "caracteres": 89,
+            "palavras": 13,
+            "textos": [
+              "Clareza, acolhimento e experiência para decidir os momentos mais importantes da sua vida."
+            ],
+            "fontFamily": "\"Cormorant Garamond\", serif",
+            "familiaEfetiva": "Cormorant Garamond",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cormorant garamond",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "600",
+            "lineHeightPx": "30px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 19,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 10,
+            "caracteres": 193,
+            "palavras": 27,
+            "textos": [
+              "Divórcio e Partilha",
+              "Guarda e Pensão",
+              "Inventário e Herança",
+              "Usucapião e Imóveis",
+              "Atendimento humanizado",
+              "Presencial e online"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "24px",
+            "lineHeightRazao": 1.33,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 14,
+            "maiorLarguraCh": 20,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 16,
+            "elementos": 7,
+            "caracteres": 381,
+            "palavras": 71,
+            "textos": [
+              "O QUE BUSCO EM CADA ATENDIMENTO",
+              "Como funciona o processo de divórcio quanto aos filhos e alimentos?\n−",
+              "Já sei que preciso de uma advogada, como inicio meu caso?\n+",
+              "Ainda estou em dúvida se preciso de um advogado. Posso conversar antes de decidir?\n+",
+              "O atendimento é só presencial em Jaguarão?\n+",
+              "Como funciona o sigilo sobre o meu caso?\n+"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "21.76px",
+            "lineHeightRazao": 1.36,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "1.36px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 23,
+            "maiorLarguraCh": 36,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 12,
+            "elementos": 3,
+            "caracteres": 21,
+            "palavras": 3,
+            "textos": [
+              "NAVEGAÇÃO",
+              "ÁREAS",
+              "CONTATO"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "16px",
+            "lineHeightRazao": 1.33,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "1.2px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 30,
+            "maiorLarguraCh": 30,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 14,
+          "fontFamily": "Poppins, sans-serif",
+          "familiaEfetiva": "Poppins",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "22.75px",
+          "lineHeightRazao": 1.63,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 31
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            32,
+            30,
+            18,
+            16,
+            12
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 22
+          },
+          "razao_semFiltro": 2,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 13,
+          "caracteresTotais": 259,
+          "caracteresPor1000px": 23.25,
+          "semNeutralizar": 13,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Poppins, sans-serif",
+            "contagem": 54
+          },
+          {
+            "familia": "\"Cormorant Garamond\", serif",
+            "contagem": 13
+          },
+          {
+            "familia": "Poppins",
+            "contagem": 4
+          },
+          {
+            "familia": "\"Cormorant Garamond\"",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 38,
+          "tag": "span",
+          "className": "font-heading text-[38px] leading-none font-semibold text-ouro shrink-0 select-none mb-2 md:mb-0",
+          "caracteres": 2,
+          "palavras": 1,
+          "fontFamily": "\"Cormorant Garamond\", serif",
+          "familiaEfetiva": "Cormorant Garamond",
+          "familiaVerificada": true,
+          "serifa": true,
+          "fontWeight": "600",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 33.6
+        },
+        "pontoCego": true,
+        "diferencaPx": 6,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            32,
+            30,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            32,
+            30,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            32,
+            30,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            32,
+            30,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            32,
+            30,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 38
+        }
+      ],
+      "rotulo": "cliente",
+      "url": "https://advocaciacieredarosa.com.br"
+    },
+    "ciere@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:28:22.958Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 10129,
+        "imgs": 9,
+        "carregadas": 8
+      },
+      "data": {
+        "url": "https://advocaciacieredarosa.com.br/",
+        "altura": 10129,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 35
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 12,
+        "telas_base900_legado": 11.3,
+        "metricaV2_hsvS015": 27.2,
+        "corPerceptivel_C005": 27.2,
+        "corForte_C012": 0.3,
+        "cromaMedioPonderado": 0.03,
+        "cromaPicoOklch": 0.145,
+        "fundos": [
+          {
+            "cor": "rgb(243,236,220)",
+            "pct": 57.7,
+            "L": 0.94,
+            "C": 0.023,
+            "H": 87
+          },
+          {
+            "cor": "rgb(77,54,28)",
+            "pct": 26.9,
+            "L": 0.35,
+            "C": 0.051,
+            "H": 68
+          },
+          {
+            "cor": "rgb(233,226,208)",
+            "pct": 10.1,
+            "L": 0.91,
+            "C": 0.025,
+            "H": 89
+          },
+          {
+            "cor": "rgb(255,253,248)",
+            "pct": 5.1,
+            "L": 0.99,
+            "C": 0.007,
+            "H": 89
+          },
+          {
+            "cor": "rgb(206,145,0)",
+            "pct": 0.3,
+            "L": 0.7,
+            "C": 0.145,
+            "H": 79
+          }
+        ],
+        "midia": {
+          "img": 9,
+          "svg": 10,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 1.88,
+        "keyframes": 3,
+        "nomes": [
+          "marquee",
+          "hero-in-left",
+          "hero-in-right"
+        ],
+        "keyframesPor1000": 0.3,
+        "folhasBloqueadas": 1,
+        "emTransicao": 28,
+        "emTransicaoPor1000": 2.76,
+        "animacoesAtivas": 1,
+        "duracoes": [
+          [
+            "0.15s",
+            18
+          ],
+          [
+            "0.3s",
+            10
+          ]
+        ],
+        "tamTitulos": [
+          32,
+          30,
+          18,
+          16,
+          12
+        ],
+        "workhorse": {
+          "px": 14,
+          "ocorrencias": 17
+        },
+        "razaoTituloWorkhorse": 2.29,
+        "titulosDetalhes": [
+          {
+            "px": 32,
+            "elementos": 6,
+            "caracteres": 290,
+            "palavras": 50,
+            "textos": [
+              "Suporte jurídico para os momentos que exigem mais cuidado",
+              "O que você encontra no meu processo",
+              "Uma advogada que entende que, por trás de cada processo, existe uma história de vida.",
+              "Quem já foi atendido, recomenda.",
+              "Perguntas que ouço com frequência",
+              "Dê o primeiro passo com quem entende seu momento"
+            ],
+            "fontFamily": "\"Cormorant Garamond\", serif",
+            "familiaEfetiva": "Cormorant Garamond",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cormorant garamond",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "600",
+            "lineHeightPx": "36.8px",
+            "lineHeightRazao": 1.15,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 19,
+            "maiorLarguraCh": 23,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 30,
+            "elementos": 1,
+            "caracteres": 89,
+            "palavras": 13,
+            "textos": [
+              "Clareza, acolhimento e experiência para decidir os momentos mais importantes da sua vida."
+            ],
+            "fontFamily": "\"Cormorant Garamond\", serif",
+            "familiaEfetiva": "Cormorant Garamond",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cormorant garamond",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "600",
+            "lineHeightPx": "30px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 24,
+            "maiorLarguraCh": 24,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 10,
+            "caracteres": 193,
+            "palavras": 27,
+            "textos": [
+              "Divórcio e Partilha",
+              "Guarda e Pensão",
+              "Inventário e Herança",
+              "Usucapião e Imóveis",
+              "Atendimento humanizado",
+              "Presencial e online"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "24px",
+            "lineHeightRazao": 1.33,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 14,
+            "maiorLarguraCh": 26,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 16,
+            "elementos": 7,
+            "caracteres": 381,
+            "palavras": 71,
+            "textos": [
+              "O QUE BUSCO EM CADA ATENDIMENTO",
+              "Como funciona o processo de divórcio quanto aos filhos e alimentos?\n−",
+              "Já sei que preciso de uma advogada, como inicio meu caso?\n+",
+              "Ainda estou em dúvida se preciso de um advogado. Posso conversar antes de decidir?\n+",
+              "O atendimento é só presencial em Jaguarão?\n+",
+              "Como funciona o sigilo sobre o meu caso?\n+"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "21.76px",
+            "lineHeightRazao": 1.36,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "1.36px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 25,
+            "maiorLarguraCh": 45,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 12,
+            "elementos": 3,
+            "caracteres": 21,
+            "palavras": 3,
+            "textos": [
+              "NAVEGAÇÃO",
+              "ÁREAS",
+              "CONTATO"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "16px",
+            "lineHeightRazao": 1.33,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "1.2px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 38,
+            "maiorLarguraCh": 38,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 14,
+          "fontFamily": "Poppins, sans-serif",
+          "familiaEfetiva": "Poppins",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "22.75px",
+          "lineHeightRazao": 1.63,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 39
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            32,
+            30,
+            18,
+            16,
+            12
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 22
+          },
+          "razao_semFiltro": 2,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 13,
+          "caracteresTotais": 259,
+          "caracteresPor1000px": 25.57,
+          "semNeutralizar": 13,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Poppins, sans-serif",
+            "contagem": 54
+          },
+          {
+            "familia": "\"Cormorant Garamond\", serif",
+            "contagem": 13
+          },
+          {
+            "familia": "Poppins",
+            "contagem": 4
+          },
+          {
+            "familia": "\"Cormorant Garamond\"",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 38,
+          "tag": "span",
+          "className": "font-heading text-[38px] leading-none font-semibold text-ouro shrink-0 select-none mb-2 md:mb-0",
+          "caracteres": 2,
+          "palavras": 1,
+          "fontFamily": "\"Cormorant Garamond\", serif",
+          "familiaEfetiva": "Cormorant Garamond",
+          "familiaVerificada": true,
+          "serifa": true,
+          "fontWeight": "600",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 32.8
+        },
+        "pontoCego": true,
+        "diferencaPx": 6,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            32,
+            30,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            32,
+            30,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            32,
+            30,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            32,
+            30,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 38
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            32,
+            30,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 38
+        }
+      ],
+      "rotulo": "cliente",
+      "url": "https://advocaciacieredarosa.com.br"
+    },
+    "ciere@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:28:33.911Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 7611,
+        "imgs": 9,
+        "carregadas": 8
+      },
+      "data": {
+        "url": "https://advocaciacieredarosa.com.br/",
+        "altura": 7611,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 35
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 7.4,
+        "telas_base900_legado": 8.5,
+        "metricaV2_hsvS015": 22.8,
+        "corPerceptivel_C005": 22.8,
+        "corForte_C012": 0.3,
+        "cromaMedioPonderado": 0.029,
+        "cromaPicoOklch": 0.145,
+        "fundos": [
+          {
+            "cor": "rgb(243,236,220)",
+            "pct": 65.1,
+            "L": 0.94,
+            "C": 0.023,
+            "H": 87
+          },
+          {
+            "cor": "rgb(77,54,28)",
+            "pct": 22.6,
+            "L": 0.35,
+            "C": 0.051,
+            "H": 68
+          },
+          {
+            "cor": "rgb(233,226,208)",
+            "pct": 8.6,
+            "L": 0.91,
+            "C": 0.025,
+            "H": 89
+          },
+          {
+            "cor": "rgb(255,253,248)",
+            "pct": 3.5,
+            "L": 0.99,
+            "C": 0.007,
+            "H": 89
+          },
+          {
+            "cor": "rgb(206,145,0)",
+            "pct": 0.3,
+            "L": 0.7,
+            "C": 0.145,
+            "H": 79
+          }
+        ],
+        "midia": {
+          "img": 9,
+          "svg": 10,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 2.5,
+        "keyframes": 3,
+        "nomes": [
+          "marquee",
+          "hero-in-left",
+          "hero-in-right"
+        ],
+        "keyframesPor1000": 0.39,
+        "folhasBloqueadas": 1,
+        "emTransicao": 28,
+        "emTransicaoPor1000": 3.68,
+        "animacoesAtivas": 1,
+        "duracoes": [
+          [
+            "0.15s",
+            18
+          ],
+          [
+            "0.3s",
+            10
+          ]
+        ],
+        "tamTitulos": [
+          48,
+          46,
+          40,
+          18,
+          16,
+          12
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 21
+        },
+        "razaoTituloWorkhorse": 3,
+        "titulosDetalhes": [
+          {
+            "px": 48,
+            "elementos": 1,
+            "caracteres": 89,
+            "palavras": 13,
+            "textos": [
+              "Clareza, acolhimento e\nexperiência para decidir\nos momentos mais\nimportantes da sua vida."
+            ],
+            "fontFamily": "\"Cormorant Garamond\", serif",
+            "familiaEfetiva": "Cormorant Garamond",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cormorant garamond",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "600",
+            "lineHeightPx": "48px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 31,
+            "maiorLarguraCh": 31,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 46,
+            "elementos": 4,
+            "caracteres": 157,
+            "palavras": 26,
+            "textos": [
+              "Suporte jurídico para os\nmomentos que exigem mais cuidado",
+              "O que você encontra no meu processo",
+              "Quem já foi atendido, recomenda.",
+              "Perguntas que ouço com frequência"
+            ],
+            "fontFamily": "\"Cormorant Garamond\", serif",
+            "familiaEfetiva": "Cormorant Garamond",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cormorant garamond",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "600",
+            "lineHeightPx": "53px",
+            "lineHeightRazao": 1.15,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 27,
+            "maiorLarguraCh": 33,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 40,
+            "elementos": 2,
+            "caracteres": 133,
+            "palavras": 24,
+            "textos": [
+              "Uma advogada que entende que, por trás de cada processo, existe uma história de vida.",
+              "Dê o primeiro passo com quem entende seu momento"
+            ],
+            "fontFamily": "\"Cormorant Garamond\", serif",
+            "familiaEfetiva": "Cormorant Garamond",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "cormorant garamond",
+            "serifa": true,
+            "serifa_pelaDeclarada_legado": true,
+            "fontWeight": "600",
+            "lineHeightPx": "50px",
+            "lineHeightRazao": 1.25,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 14,
+            "maiorLarguraCh": 16,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 10,
+            "caracteres": 193,
+            "palavras": 27,
+            "textos": [
+              "Divórcio e Partilha",
+              "Guarda e Pensão",
+              "Inventário e Herança",
+              "Usucapião e Imóveis",
+              "Atendimento humanizado",
+              "Presencial e online"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "24px",
+            "lineHeightRazao": 1.33,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 14,
+            "maiorLarguraCh": 16,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 16,
+            "elementos": 7,
+            "caracteres": 381,
+            "palavras": 71,
+            "textos": [
+              "O QUE BUSCO EM CADA ATENDIMENTO",
+              "Como funciona o processo de divórcio quanto aos filhos e alimentos?\n−",
+              "Já sei que preciso de uma advogada, como inicio meu caso?\n+",
+              "Ainda estou em dúvida se preciso de um advogado. Posso conversar antes de decidir?\n+",
+              "O atendimento é só presencial em Jaguarão?\n+",
+              "Como funciona o sigilo sobre o meu caso?\n+"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "21.76px",
+            "lineHeightRazao": 1.36,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "1.36px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 33,
+            "maiorLarguraCh": 94,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 12,
+            "elementos": 3,
+            "caracteres": 21,
+            "palavras": 3,
+            "textos": [
+              "NAVEGAÇÃO",
+              "ÁREAS",
+              "CONTATO"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "16px",
+            "lineHeightRazao": 1.33,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "1.2px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 12,
+            "maiorLarguraCh": 22,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "Poppins, sans-serif",
+          "familiaEfetiva": "Poppins",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "16px",
+          "lineHeightRazao": 1,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 30
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            48,
+            46,
+            40,
+            18,
+            16,
+            12
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 21
+          },
+          "razao_semFiltro": 3,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 13,
+          "caracteresTotais": 259,
+          "caracteresPor1000px": 34.03,
+          "semNeutralizar": 13,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Poppins, sans-serif",
+            "contagem": 60
+          },
+          {
+            "familia": "\"Cormorant Garamond\", serif",
+            "contagem": 13
+          },
+          {
+            "familia": "Poppins",
+            "contagem": 4
+          },
+          {
+            "familia": "\"Cormorant Garamond\"",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 48,
+          "tag": "h1",
+          "className": "order-2 lg:order-0 lg:col-start-1 lg:max-w-xl mt-3 lg:mt-0 text-center lg:text-left text-marrom font-heading font-semibold text-3xl sm:text-4xl md:text-5xl lg:text-6xl leading-none tracking-normal animate-hero-in-left",
+          "caracteres": 75,
+          "palavras": 10,
+          "fontFamily": "\"Cormorant Garamond\", serif",
+          "familiaEfetiva": "Cormorant Garamond",
+          "familiaVerificada": true,
+          "serifa": true,
+          "fontWeight": "600",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 1.9
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            48,
+            46,
+            40,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 48
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            48,
+            46,
+            40,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 48
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            48,
+            46,
+            40,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 48
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            48,
+            46,
+            40,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 48
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            48,
+            46,
+            40,
+            18,
+            16,
+            12
+          ],
+          "maiorTexto": 48
+        }
+      ],
+      "rotulo": "cliente",
+      "url": "https://advocaciacieredarosa.com.br"
+    },
+    "idf-br@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:28:44.657Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 2680,
+        "imgs": 12,
+        "carregadas": 12
+      },
+      "data": {
+        "url": "https://www.idf-br.com.br/home/index.html",
+        "altura": 2680,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 320,
+          "h": 568,
+          "dpr": 2
+        },
+        "telas": 4.7,
+        "telas_base900_legado": 3,
+        "metricaV2_hsvS015": 32.6,
+        "corPerceptivel_C005": 11.2,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0.015,
+        "cromaPicoOklch": 0.068,
+        "fundos": [
+          {
+            "cor": "rgb(223,223,223)",
+            "pct": 50.6,
+            "L": 0.9,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(13,27,42)",
+            "pct": 17.6,
+            "L": 0.22,
+            "C": 0.036,
+            "H": 251
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 16.9,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(19,34,56)",
+            "pct": 3.7,
+            "L": 0.25,
+            "C": 0.047,
+            "H": 258
+          },
+          {
+            "cor": "rgb(25,42,70)",
+            "pct": 3.7,
+            "L": 0.29,
+            "C": 0.057,
+            "H": 260
+          },
+          {
+            "cor": "rgb(33,55,85)",
+            "pct": 3.7,
+            "L": 0.33,
+            "C": 0.06,
+            "H": 256
+          }
+        ],
+        "midia": {
+          "img": 12,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 4.48,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 0,
+        "emTransicao": 47,
+        "emTransicaoPor1000": 17.54,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.5s",
+            18
+          ],
+          [
+            "0.3s",
+            17
+          ],
+          [
+            "0.4s",
+            12
+          ],
+          [
+            "0.2s",
+            10
+          ],
+          [
+            "0.6s",
+            4
+          ],
+          [
+            "0.8s",
+            2
+          ]
+        ],
+        "tamTitulos": [
+          35,
+          18
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 10
+        },
+        "razaoTituloWorkhorse": 2.19,
+        "titulosDetalhes": [
+          {
+            "px": 35,
+            "elementos": 1,
+            "caracteres": 6,
+            "palavras": 1,
+            "textos": [
+              "IDF-BR"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "normal",
+            "lineHeightRazao": 1.14,
+            "lineHeightOrigem": "normal-medida",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 4,
+            "caracteres": 56,
+            "palavras": 12,
+            "textos": [
+              "IDF - CLIMA ATUAL",
+              "IDF - CLIMA FUTURO",
+              "SOBRE",
+              "ENTRE EM CONTATO"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "normal",
+            "lineHeightRazao": 1.17,
+            "lineHeightOrigem": "normal-medida",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 16,
+            "maiorLarguraCh": 18,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "Poppins, sans-serif",
+          "familiaEfetiva": "Poppins",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "normal",
+          "lineHeightRazao": 1.13,
+          "lineHeightOrigem": "normal-medida",
+          "largura_ch": 29
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            35,
+            18
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 14
+          },
+          "razao_semFiltro": 2.19,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Poppins, sans-serif",
+            "contagem": 16
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 35,
+          "tag": "h1",
+          "className": "item-title",
+          "caracteres": 6,
+          "palavras": 1,
+          "fontFamily": "Poppins, sans-serif",
+          "familiaEfetiva": "Poppins",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 6.9
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        }
+      ],
+      "rotulo": "cliente",
+      "url": "https://idf-br.com.br"
+    },
+    "idf-br@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:28:54.933Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 2370,
+        "imgs": 12,
+        "carregadas": 12
+      },
+      "data": {
+        "url": "https://www.idf-br.com.br/home/index.html",
+        "altura": 2370,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 2.8,
+        "telas_base900_legado": 2.6,
+        "metricaV2_hsvS015": 30.9,
+        "corPerceptivel_C005": 12.4,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0.015,
+        "cromaPicoOklch": 0.068,
+        "fundos": [
+          {
+            "cor": "rgb(223,223,223)",
+            "pct": 47.4,
+            "L": 0.9,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 21.8,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(13,27,42)",
+            "pct": 14.3,
+            "L": 0.22,
+            "C": 0.036,
+            "H": 251
+          },
+          {
+            "cor": "rgb(19,34,56)",
+            "pct": 4.1,
+            "L": 0.25,
+            "C": 0.047,
+            "H": 258
+          },
+          {
+            "cor": "rgb(25,42,70)",
+            "pct": 4.1,
+            "L": 0.29,
+            "C": 0.057,
+            "H": 260
+          },
+          {
+            "cor": "rgb(33,55,85)",
+            "pct": 4.1,
+            "L": 0.33,
+            "C": 0.06,
+            "H": 256
+          }
+        ],
+        "midia": {
+          "img": 12,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 5.06,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 0,
+        "emTransicao": 47,
+        "emTransicaoPor1000": 19.83,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.5s",
+            18
+          ],
+          [
+            "0.3s",
+            17
+          ],
+          [
+            "0.4s",
+            12
+          ],
+          [
+            "0.2s",
+            10
+          ],
+          [
+            "0.6s",
+            4
+          ],
+          [
+            "0.8s",
+            2
+          ]
+        ],
+        "tamTitulos": [
+          35,
+          18
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 10
+        },
+        "razaoTituloWorkhorse": 2.19,
+        "titulosDetalhes": [
+          {
+            "px": 35,
+            "elementos": 1,
+            "caracteres": 6,
+            "palavras": 1,
+            "textos": [
+              "IDF-BR"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "normal",
+            "lineHeightRazao": 1.14,
+            "lineHeightOrigem": "normal-medida",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 13,
+            "maiorLarguraCh": 13,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 4,
+            "caracteres": 56,
+            "palavras": 12,
+            "textos": [
+              "IDF - CLIMA ATUAL",
+              "IDF - CLIMA FUTURO",
+              "SOBRE",
+              "ENTRE EM CONTATO"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "normal",
+            "lineHeightRazao": 1.17,
+            "lineHeightOrigem": "normal-medida",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 16,
+            "maiorLarguraCh": 18,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "Poppins, sans-serif",
+          "familiaEfetiva": "Poppins",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "normal",
+          "lineHeightRazao": 1.13,
+          "lineHeightOrigem": "normal-medida",
+          "largura_ch": 34
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            35,
+            18
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 14
+          },
+          "razao_semFiltro": 2.19,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Poppins, sans-serif",
+            "contagem": 16
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 35,
+          "tag": "h1",
+          "className": "item-title",
+          "caracteres": 6,
+          "palavras": 1,
+          "fontFamily": "Poppins, sans-serif",
+          "familiaEfetiva": "Poppins",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 7.8
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        }
+      ],
+      "rotulo": "cliente",
+      "url": "https://idf-br.com.br"
+    },
+    "idf-br@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:29:05.083Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 1920,
+        "imgs": 12,
+        "carregadas": 12
+      },
+      "data": {
+        "url": "https://www.idf-br.com.br/home/index.html",
+        "altura": 1920,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 1.9,
+        "telas_base900_legado": 2.1,
+        "metricaV2_hsvS015": 31.8,
+        "corPerceptivel_C005": 16.9,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0.016,
+        "cromaPicoOklch": 0.068,
+        "fundos": [
+          {
+            "cor": "rgb(223,223,223)",
+            "pct": 47.7,
+            "L": 0.9,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 20.5,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(13,27,42)",
+            "pct": 9.2,
+            "L": 0.22,
+            "C": 0.036,
+            "H": 251
+          },
+          {
+            "cor": "rgb(19,34,56)",
+            "pct": 5.6,
+            "L": 0.25,
+            "C": 0.047,
+            "H": 258
+          },
+          {
+            "cor": "rgb(25,42,70)",
+            "pct": 5.6,
+            "L": 0.29,
+            "C": 0.057,
+            "H": 260
+          },
+          {
+            "cor": "rgb(33,55,85)",
+            "pct": 5.6,
+            "L": 0.33,
+            "C": 0.06,
+            "H": 256
+          }
+        ],
+        "midia": {
+          "img": 12,
+          "svg": 0,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 6.25,
+        "keyframes": 0,
+        "nomes": [],
+        "keyframesPor1000": 0,
+        "folhasBloqueadas": 0,
+        "emTransicao": 47,
+        "emTransicaoPor1000": 24.48,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.5s",
+            18
+          ],
+          [
+            "0.3s",
+            17
+          ],
+          [
+            "0.4s",
+            12
+          ],
+          [
+            "0.2s",
+            10
+          ],
+          [
+            "0.6s",
+            4
+          ],
+          [
+            "0.8s",
+            2
+          ]
+        ],
+        "tamTitulos": [
+          35,
+          18
+        ],
+        "workhorse": {
+          "px": 16,
+          "ocorrencias": 10
+        },
+        "razaoTituloWorkhorse": 2.19,
+        "titulosDetalhes": [
+          {
+            "px": 35,
+            "elementos": 1,
+            "caracteres": 6,
+            "palavras": 1,
+            "textos": [
+              "IDF-BR"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "normal",
+            "lineHeightRazao": 1.14,
+            "lineHeightOrigem": "normal-medida",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 32,
+            "maiorLarguraCh": 32,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 18,
+            "elementos": 4,
+            "caracteres": 56,
+            "palavras": 12,
+            "textos": [
+              "IDF - CLIMA ATUAL",
+              "IDF - CLIMA FUTURO",
+              "SOBRE",
+              "ENTRE EM CONTATO"
+            ],
+            "fontFamily": "Poppins, sans-serif",
+            "familiaEfetiva": "Poppins",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "poppins",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "normal",
+            "lineHeightRazao": 1.17,
+            "lineHeightOrigem": "normal-medida",
+            "letterSpacing": "normal",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 16,
+            "maiorLarguraCh": 18,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 16,
+          "fontFamily": "Poppins, sans-serif",
+          "familiaEfetiva": "Poppins",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "normal",
+          "lineHeightRazao": 1.13,
+          "lineHeightOrigem": "normal-medida",
+          "largura_ch": 34
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            35,
+            18
+          ],
+          "workhorse_semFiltro": {
+            "px": 16,
+            "ocorrencias": 14
+          },
+          "razao_semFiltro": 2.19,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Poppins, sans-serif",
+            "contagem": 16
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 35,
+          "tag": "h1",
+          "className": "item-title",
+          "caracteres": 6,
+          "palavras": 1,
+          "fontFamily": "Poppins, sans-serif",
+          "familiaEfetiva": "Poppins",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 9.6
+        },
+        "pontoCego": false,
+        "diferencaPx": 0,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            35,
+            18
+          ],
+          "maiorTexto": 35
+        }
+      ],
+      "rotulo": "cliente",
+      "url": "https://idf-br.com.br"
+    },
+    "dvo@320": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:29:15.483Z",
+      "viewport": "320x568x2",
+      "rolagem": {
+        "altura": 568,
+        "imgs": 1,
+        "carregadas": 1
+      },
+      "data": {
+        "url": "https://dvopelotas.com.br/",
+        "altura": 568,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 320,
+          "h": 568,
+          "dpr": 2
+        },
+        "telas": 1,
+        "telas_base900_legado": 0.6,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 100,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 1,
+          "svg": 1,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 3.52,
+        "keyframes": 7,
+        "nomes": [
+          "swipe-out-left",
+          "swipe-out-right",
+          "swipe-out-up",
+          "swipe-out-down",
+          "sonner-fade-in",
+          "sonner-fade-out",
+          "sonner-spin"
+        ],
+        "keyframesPor1000": 12.32,
+        "folhasBloqueadas": 0,
+        "emTransicao": 4,
+        "emTransicaoPor1000": 7.04,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.15s",
+            3
+          ],
+          [
+            "0.2s",
+            1
+          ]
+        ],
+        "tamTitulos": [],
+        "workhorse": {
+          "px": 18,
+          "ocorrencias": 1
+        },
+        "razaoTituloWorkhorse": null,
+        "titulosDetalhes": [],
+        "workhorseDetalhe": {
+          "px": 18,
+          "fontFamily": "Arial, Helvetica, sans-serif",
+          "familiaEfetiva": "Arial",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "28px",
+          "lineHeightRazao": 1.56,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 19
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            60,
+            24
+          ],
+          "workhorse_semFiltro": {
+            "px": 18,
+            "ocorrencias": 1
+          },
+          "razao_semFiltro": 3.33,
+          "divergeDoCorrigido": true
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 60,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "DVO"
+            },
+            {
+              "px": 24,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "Departamento de Veículos e Oficinas"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Arial, Helvetica, sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 18,
+          "tag": "p",
+          "className": "font-bold text-black-400 text-lg",
+          "caracteres": 21,
+          "palavras": 5,
+          "fontFamily": "Arial, Helvetica, sans-serif",
+          "familiaEfetiva": "Arial",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 37.6
+        },
+        "pontoCego": true,
+        "diferencaPx": 18,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        }
+      ],
+      "rotulo": "cliente",
+      "url": "https://dvopelotas.com.br"
+    },
+    "dvo@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:29:25.491Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 844,
+        "imgs": 1,
+        "carregadas": 1
+      },
+      "data": {
+        "url": "https://dvopelotas.com.br/",
+        "altura": 844,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 1,
+        "telas_base900_legado": 0.9,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 100,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 1,
+          "svg": 1,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 2.37,
+        "keyframes": 7,
+        "nomes": [
+          "swipe-out-left",
+          "swipe-out-right",
+          "swipe-out-up",
+          "swipe-out-down",
+          "sonner-fade-in",
+          "sonner-fade-out",
+          "sonner-spin"
+        ],
+        "keyframesPor1000": 8.29,
+        "folhasBloqueadas": 0,
+        "emTransicao": 4,
+        "emTransicaoPor1000": 4.74,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.15s",
+            3
+          ],
+          [
+            "0.2s",
+            1
+          ]
+        ],
+        "tamTitulos": [],
+        "workhorse": {
+          "px": 18,
+          "ocorrencias": 1
+        },
+        "razaoTituloWorkhorse": null,
+        "titulosDetalhes": [],
+        "workhorseDetalhe": {
+          "px": 18,
+          "fontFamily": "Arial, Helvetica, sans-serif",
+          "familiaEfetiva": "Arial",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "28px",
+          "lineHeightRazao": 1.56,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 19
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            60,
+            24
+          ],
+          "workhorse_semFiltro": {
+            "px": 18,
+            "ocorrencias": 1
+          },
+          "razao_semFiltro": 3.33,
+          "divergeDoCorrigido": true
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 60,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "DVO"
+            },
+            {
+              "px": 24,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "Departamento de Veículos e Oficinas"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Arial, Helvetica, sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 18,
+          "tag": "p",
+          "className": "font-bold text-black-400 text-lg",
+          "caracteres": 21,
+          "palavras": 5,
+          "fontFamily": "Arial, Helvetica, sans-serif",
+          "familiaEfetiva": "Arial",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 41.6
+        },
+        "pontoCego": true,
+        "diferencaPx": 18,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        }
+      ],
+      "rotulo": "cliente",
+      "url": "https://dvopelotas.com.br"
+    },
+    "dvo@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:29:35.419Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 1024,
+        "imgs": 1,
+        "carregadas": 1
+      },
+      "data": {
+        "url": "https://dvopelotas.com.br/",
+        "altura": 1024,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 0
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 1,
+        "telas_base900_legado": 1.1,
+        "metricaV2_hsvS015": 0,
+        "corPerceptivel_C005": 0,
+        "corForte_C012": 0,
+        "cromaMedioPonderado": 0,
+        "cromaPicoOklch": 0,
+        "fundos": [
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 100,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 1,
+          "svg": 1,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 1.95,
+        "keyframes": 7,
+        "nomes": [
+          "swipe-out-left",
+          "swipe-out-right",
+          "swipe-out-up",
+          "swipe-out-down",
+          "sonner-fade-in",
+          "sonner-fade-out",
+          "sonner-spin"
+        ],
+        "keyframesPor1000": 6.84,
+        "folhasBloqueadas": 0,
+        "emTransicao": 4,
+        "emTransicaoPor1000": 3.91,
+        "animacoesAtivas": 0,
+        "duracoes": [
+          [
+            "0.15s",
+            3
+          ],
+          [
+            "0.2s",
+            1
+          ]
+        ],
+        "tamTitulos": [],
+        "workhorse": {
+          "px": 18,
+          "ocorrencias": 1
+        },
+        "razaoTituloWorkhorse": null,
+        "titulosDetalhes": [],
+        "workhorseDetalhe": {
+          "px": 18,
+          "fontFamily": "Arial, Helvetica, sans-serif",
+          "familiaEfetiva": "Arial",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "28px",
+          "lineHeightRazao": 1.56,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 19
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            60,
+            24
+          ],
+          "workhorse_semFiltro": {
+            "px": 18,
+            "ocorrencias": 1
+          },
+          "razao_semFiltro": 3.33,
+          "divergeDoCorrigido": true
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 60,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "DVO"
+            },
+            {
+              "px": 24,
+              "motivo": "sem-caixa-renderizada",
+              "texto": "Departamento de Veículos e Oficinas"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 0,
+          "caracteresTotais": 0,
+          "caracteresPor1000px": 0,
+          "semNeutralizar": 0,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Arial, Helvetica, sans-serif",
+            "contagem": 1
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 18,
+          "tag": "p",
+          "className": "font-bold text-black-400 text-lg",
+          "caracteres": 21,
+          "palavras": 5,
+          "fontFamily": "Arial, Helvetica, sans-serif",
+          "familiaEfetiva": "Arial",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 43.7
+        },
+        "pontoCego": true,
+        "diferencaPx": 18,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [],
+          "maiorTexto": 18
+        }
+      ],
+      "rotulo": "cliente",
+      "url": "https://dvopelotas.com.br"
+    }
+  },
+  "variantesDaLP": {}
+}

--- a/docs/design/tipografia/medicoes.json
+++ b/docs/design/tipografia/medicoes.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "gerado": "2026-09-10T17:46:17.112Z",
+    "gerado": "2026-09-11T01:01:44.682Z",
     "comando": "node docs/design/tipografia/medir.mjs --headed",
     "comandoOficial": "node docs/design/tipografia/medir.mjs --headed",
     "modo": "headed",
@@ -9,14 +9,14 @@
     "alvos": "docs/design/tipografia/alvos.json",
     "nota": "Nao ha arquivo de prototipo. O \"depois\" da escala e medido por injecao de CSS sobre a wireframes/lp-final.html real. Ver provenance.md P-015.",
     "notaCaixaAlta": "caixaAlta.semNeutralizar NAO e numero citavel: e a contagem sem neutralizar o revelador, ou seja, a propria grandeza nao deterministica que a issue #46 conserta, e varia entre rodadas. Existe so para dimensionar quanto o revelador escondia. O numero valido e caixaAlta.elementos, medido no passe neutralizado.",
-    "total": 24,
-    "sucessos": 24,
+    "total": 33,
+    "sucessos": 33,
     "falhas": []
   },
   "referencias": {
     "aelixa": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:46:30.942Z",
+      "dataHora": "2026-09-11T01:01:58.279Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 17502,
@@ -520,7 +520,7 @@
     },
     "illoca": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:46:43.316Z",
+      "dataHora": "2026-09-11T01:02:09.897Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 900,
@@ -917,7 +917,7 @@
     },
     "paulkalkbrenner": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:47:00.915Z",
+      "dataHora": "2026-09-11T01:02:29.794Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 10709,
@@ -1190,32 +1190,7 @@
         },
         "descartes": {
           "titulos": [],
-          "porRecorte": [
-            {
-              "px": 641,
-              "tag": "span",
-              "fracaoContida": 0.05,
-              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
-            },
-            {
-              "px": 641,
-              "tag": "span",
-              "fracaoContida": 0.05,
-              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
-            },
-            {
-              "px": 641,
-              "tag": "span",
-              "fracaoContida": 0.05,
-              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
-            },
-            {
-              "px": 641,
-              "tag": "span",
-              "fracaoContida": 0.05,
-              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
-            }
-          ]
+          "porRecorte": []
         },
         "caixaAlta": {
           "elementos": 183,
@@ -1232,22 +1207,22 @@
           }
         ],
         "maiorTextoRenderizado": {
-          "px": 150,
+          "px": 641,
           "tag": "span",
-          "className": "h-d__span",
-          "caracteres": 4,
+          "className": "",
+          "caracteres": 1,
           "palavras": 1,
           "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
           "familiaEfetiva": "ABC Diatype Plus Variable",
           "familiaVerificada": true,
           "serifa": false,
-          "fontWeight": "700",
+          "fontWeight": "400",
           "textTransform": "none",
           "fracaoContida": 1,
-          "profundidadeDeRolagem": 3.4
+          "profundidadeDeRolagem": 83.1
         },
-        "pontoCego": false,
-        "diferencaPx": 0,
+        "pontoCego": true,
+        "diferencaPx": 491,
         "_amostras": 5,
         "_instavel": false
       },
@@ -1300,7 +1275,7 @@
             18,
             11
           ],
-          "maiorTexto": 150
+          "maiorTexto": 641
         }
       ],
       "rotulo": "aprovado",
@@ -1308,7 +1283,7 @@
     },
     "lxlcreative": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:47:19.585Z",
+      "dataHora": "2026-09-11T01:02:46.807Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 15323,
@@ -1790,7 +1765,7 @@
     },
     "white-desert": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:47:35.808Z",
+      "dataHora": "2026-09-11T01:03:01.949Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 20787,
@@ -2296,12 +2271,12 @@
     },
     "charityshot": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:47:46.650Z",
+      "dataHora": "2026-09-11T01:03:12.060Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 900,
         "imgs": 73,
-        "carregadas": 46
+        "carregadas": 45
       },
       "data": {
         "url": "https://charityshot.co.uk/",
@@ -2515,7 +2490,7 @@
     },
     "obspogon": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:48:03.196Z",
+      "dataHora": "2026-09-11T01:03:28.317Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 3061,
@@ -2753,7 +2728,7 @@
     },
     "paulfragara": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:48:13.682Z",
+      "dataHora": "2026-09-11T01:03:39.527Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 1431,
@@ -3028,7 +3003,7 @@
     },
     "lowmess": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:48:24.814Z",
+      "dataHora": "2026-09-11T01:03:50.681Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 1234,
@@ -3302,12 +3277,12 @@
     },
     "simonbetton": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:48:37.357Z",
+      "dataHora": "2026-09-11T01:04:03.794Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 9298,
         "imgs": 14,
-        "carregadas": 5
+        "carregadas": 6
       },
       "data": {
         "url": "https://www.simonbetton.com/",
@@ -3648,7 +3623,7 @@
     },
     "nextfive": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:48:49.088Z",
+      "dataHora": "2026-09-11T01:04:15.562Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 2915,
@@ -3978,7 +3953,7 @@
     },
     "incomescrane": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:49:00.689Z",
+      "dataHora": "2026-09-11T01:04:27.237Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 4056,
@@ -4199,7 +4174,7 @@
     },
     "shelomoh": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:49:12.389Z",
+      "dataHora": "2026-09-11T01:04:38.446Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 2364,
@@ -4459,7 +4434,7 @@
     },
     "thatmlopsguy": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:49:23.215Z",
+      "dataHora": "2026-09-11T01:04:49.188Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 3602,
@@ -4828,7 +4803,7 @@
     },
     "cassidoo": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:49:37.234Z",
+      "dataHora": "2026-09-11T01:05:00.123Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 1654,
@@ -5088,7 +5063,7 @@
     },
     "ciere": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:49:48.589Z",
+      "dataHora": "2026-09-11T01:05:11.358Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 6297,
@@ -5516,7 +5491,7 @@
     },
     "idf-br": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:49:59.337Z",
+      "dataHora": "2026-09-11T01:05:22.039Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 929,
@@ -5802,7 +5777,7 @@
     },
     "dvo": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:50:09.584Z",
+      "dataHora": "2026-09-11T01:05:32.747Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 900,
@@ -6042,73 +6017,73 @@
     }
   },
   "variantesDaLP": {
-    "A-lp-atual@1440": {
+    "A-lp-atual@320": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:50:21.166Z",
-      "viewport": "1440x900x1",
+      "dataHora": "2026-09-11T01:05:44.717Z",
+      "viewport": "320x568x2",
       "rolagem": {
-        "altura": 8374,
+        "altura": 11644,
         "imgs": 0,
         "carregadas": 0
       },
       "data": {
-        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html",
-        "altura": 8374,
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
+        "altura": 11644,
         "fontes": {
           "status": "loaded",
           "carregadas": 33
         },
         "viewportMedido": {
-          "w": 1440,
-          "h": 900,
-          "dpr": 1
+          "w": 320,
+          "h": 568,
+          "dpr": 2
         },
-        "telas": 9.3,
-        "telas_base900_legado": 9.3,
-        "metricaV2_hsvS015": 0.5,
-        "corPerceptivel_C005": 0.5,
-        "corForte_C012": 0.4,
-        "cromaMedioPonderado": 0.009,
+        "telas": 20.5,
+        "telas_base900_legado": 12.9,
+        "metricaV2_hsvS015": 1,
+        "corPerceptivel_C005": 1,
+        "corForte_C012": 0.9,
+        "cromaMedioPonderado": 0.01,
         "cromaPicoOklch": 0.201,
         "fundos": [
           {
             "cor": "rgb(247,245,239)",
-            "pct": 68.6,
+            "pct": 66.6,
             "L": 0.97,
             "C": 0.008,
             "H": 91
           },
           {
             "cor": "rgb(232,227,217)",
-            "pct": 15,
+            "pct": 14.9,
             "L": 0.92,
             "C": 0.014,
             "H": 85
           },
           {
             "cor": "rgb(17,18,19)",
-            "pct": 7.6,
+            "pct": 7.5,
             "L": 0.18,
             "C": 0.003,
             "H": 248
           },
           {
             "cor": "rgb(11,11,11)",
-            "pct": 6,
+            "pct": 5.3,
             "L": 0.15,
             "C": 0,
             "H": 90
           },
           {
             "cor": "rgb(255,255,255)",
-            "pct": 1.5,
+            "pct": 3.1,
             "L": 1,
             "C": 0,
             "H": 90
           },
           {
             "cor": "rgb(241,238,230)",
-            "pct": 0.6,
+            "pct": 1.2,
             "L": 0.95,
             "C": 0.011,
             "H": 90
@@ -6120,18 +6095,18 @@
           "video": 0,
           "canvas": 0
         },
-        "midiaTotalPor1000": 0.24,
+        "midiaTotalPor1000": 0.17,
         "keyframes": 3,
         "nomes": [
           "rail-scroll",
           "heroUp",
           "heroLine"
         ],
-        "keyframesPor1000": 0.36,
+        "keyframesPor1000": 0.26,
         "folhasBloqueadas": 1,
         "emTransicao": 75,
-        "emTransicaoPor1000": 8.96,
-        "animacoesAtivas": 9,
+        "emTransicaoPor1000": 6.44,
+        "animacoesAtivas": 8,
         "duracoes": [
           [
             "0.6s",
@@ -6147,18 +6122,18 @@
           ]
         ],
         "tamTitulos": [
-          46,
-          34,
+          27,
+          21,
           10
         ],
         "workhorse": {
           "px": 13,
           "ocorrencias": 9
         },
-        "razaoTituloWorkhorse": 3.54,
+        "razaoTituloWorkhorse": 2.08,
         "titulosDetalhes": [
           {
-            "px": 46,
+            "px": 27,
             "elementos": 1,
             "caracteres": 59,
             "palavras": 8,
@@ -6173,19 +6148,19 @@
             "serifa": false,
             "serifa_pelaDeclarada_legado": false,
             "fontWeight": "700",
-            "lineHeightPx": "48.256px",
+            "lineHeightPx": "28.288px",
             "lineHeightRazao": 1.05,
             "lineHeightOrigem": "declarada",
-            "letterSpacing": "-1.392px",
+            "letterSpacing": "-0.816px",
             "textTransform": "uppercase",
             "inFirstViewport": true,
-            "largura_ch": 19,
-            "maiorLarguraCh": 19,
+            "largura_ch": 16,
+            "maiorLarguraCh": 16,
             "fracaoContidaMin": 1,
             "vistoEmAmostras": "5/5"
           },
           {
-            "px": 34,
+            "px": 21,
             "elementos": 7,
             "caracteres": 437,
             "palavras": 62,
@@ -6205,14 +6180,14 @@
             "serifa": false,
             "serifa_pelaDeclarada_legado": false,
             "fontWeight": "600",
-            "lineHeightPx": "40.592px",
-            "lineHeightRazao": 1.19,
+            "lineHeightPx": "24.544px",
+            "lineHeightRazao": 1.17,
             "lineHeightOrigem": "declarada",
-            "letterSpacing": "-0.86px",
+            "letterSpacing": "-0.52px",
             "textTransform": "none",
             "inFirstViewport": false,
-            "largura_ch": 25,
-            "maiorLarguraCh": 51,
+            "largura_ch": 21,
+            "maiorLarguraCh": 21,
             "fracaoContidaMin": 1,
             "vistoEmAmostras": "5/5"
           },
@@ -6239,8 +6214,8 @@
             "letterSpacing": "1.152px",
             "textTransform": "uppercase",
             "inFirstViewport": false,
-            "largura_ch": 40,
-            "maiorLarguraCh": 40,
+            "largura_ch": 19,
+            "maiorLarguraCh": 19,
             "fracaoContidaMin": 1,
             "vistoEmAmostras": "5/5"
           }
@@ -6258,16 +6233,16 @@
         },
         "_legado": {
           "tamTitulos_semFiltro": [
-            46,
-            34,
+            27,
+            21,
             11,
             10
           ],
           "workhorse_semFiltro": {
-            "px": 14,
-            "ocorrencias": 16
+            "px": 13,
+            "ocorrencias": 19
           },
-          "razao_semFiltro": 3.29,
+          "razao_semFiltro": 2.08,
           "divergeDoCorrigido": false
         },
         "descartes": {
@@ -6286,10 +6261,10 @@
           "porRecorte": []
         },
         "caixaAlta": {
-          "elementos": 96,
-          "caracteresTotais": 1513,
-          "caracteresPor1000px": 180.68,
-          "semNeutralizar": 55,
+          "elementos": 89,
+          "caracteresTotais": 1419,
+          "caracteresPor1000px": 121.87,
+          "semNeutralizar": 48,
           "passeNeutralizado": true,
           "amostras": 6
         },
@@ -6308,7 +6283,7 @@
           }
         ],
         "maiorTextoRenderizado": {
-          "px": 232,
+          "px": 60,
           "tag": "div",
           "className": "footer-wordmark",
           "caracteres": 7,
@@ -6320,10 +6295,10 @@
           "fontWeight": "700",
           "textTransform": "none",
           "fracaoContida": 1,
-          "profundidadeDeRolagem": 95.9
+          "profundidadeDeRolagem": 98.3
         },
         "pontoCego": true,
-        "diferencaPx": 186,
+        "diferencaPx": 33,
         "_amostras": 5,
         "_instavel": false
       },
@@ -6331,119 +6306,119 @@
         {
           "quando": "t+4s",
           "tamTitulos": [
-            46,
-            34,
+            27,
+            21,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         },
         {
           "quando": "t+5.5s",
           "tamTitulos": [
-            46,
-            34,
+            27,
+            21,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         },
         {
           "quando": "t+7s",
           "tamTitulos": [
-            46,
-            34,
+            27,
+            21,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         },
         {
           "quando": "t+8.5s",
           "tamTitulos": [
-            46,
-            34,
+            27,
+            21,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         },
         {
           "quando": "pos-rolagem",
           "tamTitulos": [
-            46,
-            34,
+            27,
+            21,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         }
       ],
       "variante": "A-lp-atual",
-      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html"
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
     },
-    "B-so-escala@1440": {
+    "B-so-escala@320": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:50:33.521Z",
-      "viewport": "1440x900x1",
+      "dataHora": "2026-09-11T01:05:57.170Z",
+      "viewport": "320x568x2",
       "rolagem": {
-        "altura": 10604,
+        "altura": 13484,
         "imgs": 0,
         "carregadas": 0
       },
       "data": {
-        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html",
-        "altura": 10604,
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
+        "altura": 13484,
         "fontes": {
           "status": "loaded",
           "carregadas": 33
         },
         "viewportMedido": {
-          "w": 1440,
-          "h": 900,
-          "dpr": 1
+          "w": 320,
+          "h": 568,
+          "dpr": 2
         },
-        "telas": 11.8,
-        "telas_base900_legado": 11.8,
-        "metricaV2_hsvS015": 0.4,
-        "corPerceptivel_C005": 0.4,
-        "corForte_C012": 0.4,
-        "cromaMedioPonderado": 0.009,
+        "telas": 23.7,
+        "telas_base900_legado": 15,
+        "metricaV2_hsvS015": 0.9,
+        "corPerceptivel_C005": 0.9,
+        "corForte_C012": 0.8,
+        "cromaMedioPonderado": 0.01,
         "cromaPicoOklch": 0.201,
         "fundos": [
           {
             "cor": "rgb(247,245,239)",
-            "pct": 68.1,
+            "pct": 65.8,
             "L": 0.97,
             "C": 0.008,
             "H": 91
           },
           {
             "cor": "rgb(232,227,217)",
-            "pct": 17.3,
+            "pct": 16.7,
             "L": 0.92,
             "C": 0.014,
             "H": 85
           },
           {
             "cor": "rgb(17,18,19)",
-            "pct": 6.8,
+            "pct": 7.3,
             "L": 0.18,
             "C": 0.003,
             "H": 248
           },
           {
             "cor": "rgb(11,11,11)",
-            "pct": 5.4,
+            "pct": 5.1,
             "L": 0.15,
             "C": 0,
             "H": 90
           },
           {
             "cor": "rgb(255,255,255)",
-            "pct": 1.3,
+            "pct": 2.8,
             "L": 1,
             "C": 0,
             "H": 90
           },
           {
             "cor": "rgb(241,238,230)",
-            "pct": 0.5,
+            "pct": 1.1,
             "L": 0.95,
             "C": 0.011,
             "H": 90
@@ -6455,18 +6430,18 @@
           "video": 0,
           "canvas": 0
         },
-        "midiaTotalPor1000": 0.19,
+        "midiaTotalPor1000": 0.15,
         "keyframes": 3,
         "nomes": [
           "rail-scroll",
           "heroUp",
           "heroLine"
         ],
-        "keyframesPor1000": 0.28,
+        "keyframesPor1000": 0.22,
         "folhasBloqueadas": 1,
         "emTransicao": 75,
-        "emTransicaoPor1000": 7.07,
-        "animacoesAtivas": 9,
+        "emTransicaoPor1000": 5.56,
+        "animacoesAtivas": 8,
         "duracoes": [
           [
             "0.6s",
@@ -6482,18 +6457,18 @@
           ]
         ],
         "tamTitulos": [
-          144,
-          72,
+          48,
+          36,
           10
         ],
         "workhorse": {
           "px": 13,
           "ocorrencias": 9
         },
-        "razaoTituloWorkhorse": 11.08,
+        "razaoTituloWorkhorse": 3.69,
         "titulosDetalhes": [
           {
-            "px": 144,
+            "px": 48,
             "elementos": 1,
             "caracteres": 59,
             "palavras": 8,
@@ -6508,19 +6483,19 @@
             "serifa": false,
             "serifa_pelaDeclarada_legado": false,
             "fontWeight": "700",
-            "lineHeightPx": "129.6px",
+            "lineHeightPx": "43.2px",
             "lineHeightRazao": 0.9,
             "lineHeightOrigem": "declarada",
-            "letterSpacing": "-5.76px",
+            "letterSpacing": "-1.92px",
             "textTransform": "none",
             "inFirstViewport": true,
-            "largura_ch": 8,
-            "maiorLarguraCh": 8,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
             "fracaoContidaMin": 1,
             "vistoEmAmostras": "5/5"
           },
           {
-            "px": 72,
+            "px": 36,
             "elementos": 7,
             "caracteres": 437,
             "palavras": 62,
@@ -6540,14 +6515,14 @@
             "serifa": false,
             "serifa_pelaDeclarada_legado": false,
             "fontWeight": "600",
-            "lineHeightPx": "75.6px",
+            "lineHeightPx": "37.8px",
             "lineHeightRazao": 1.05,
             "lineHeightOrigem": "declarada",
-            "letterSpacing": "-1.44px",
+            "letterSpacing": "-0.72px",
             "textTransform": "none",
             "inFirstViewport": false,
-            "largura_ch": 24,
-            "maiorLarguraCh": 24,
+            "largura_ch": 12,
+            "maiorLarguraCh": 12,
             "fracaoContidaMin": 1,
             "vistoEmAmostras": "5/5"
           },
@@ -6574,8 +6549,8 @@
             "letterSpacing": "0.192px",
             "textTransform": "none",
             "inFirstViewport": false,
-            "largura_ch": 47,
-            "maiorLarguraCh": 47,
+            "largura_ch": 22,
+            "maiorLarguraCh": 22,
             "fracaoContidaMin": 1,
             "vistoEmAmostras": "5/5"
           }
@@ -6593,16 +6568,16 @@
         },
         "_legado": {
           "tamTitulos_semFiltro": [
-            144,
-            72,
+            48,
+            36,
             11,
             10
           ],
           "workhorse_semFiltro": {
-            "px": 14,
-            "ocorrencias": 16
+            "px": 13,
+            "ocorrencias": 19
           },
-          "razao_semFiltro": 10.29,
+          "razao_semFiltro": 3.69,
           "divergeDoCorrigido": false
         },
         "descartes": {
@@ -6623,7 +6598,7 @@
         "caixaAlta": {
           "elementos": 23,
           "caracteresTotais": 467,
-          "caracteresPor1000px": 44.04,
+          "caracteresPor1000px": 34.63,
           "semNeutralizar": 13,
           "passeNeutralizado": true,
           "amostras": 6
@@ -6643,7 +6618,7 @@
           }
         ],
         "maiorTextoRenderizado": {
-          "px": 232,
+          "px": 60,
           "tag": "div",
           "className": "footer-wordmark",
           "caracteres": 7,
@@ -6655,10 +6630,10 @@
           "fontWeight": "700",
           "textTransform": "none",
           "fracaoContida": 1,
-          "profundidadeDeRolagem": 96.7
+          "profundidadeDeRolagem": 98.5
         },
         "pontoCego": true,
-        "diferencaPx": 88,
+        "diferencaPx": 12,
         "_amostras": 5,
         "_instavel": false
       },
@@ -6666,119 +6641,119 @@
         {
           "quando": "t+4s",
           "tamTitulos": [
-            144,
-            72,
+            48,
+            36,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         },
         {
           "quando": "t+5.5s",
           "tamTitulos": [
-            144,
-            72,
+            48,
+            36,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         },
         {
           "quando": "t+7s",
           "tamTitulos": [
-            144,
-            72,
+            48,
+            36,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         },
         {
           "quando": "t+8.5s",
           "tamTitulos": [
-            144,
-            72,
+            48,
+            36,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         },
         {
           "quando": "pos-rolagem",
           "tamTitulos": [
-            144,
-            72,
+            48,
+            36,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         }
       ],
       "variante": "B-so-escala",
-      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html"
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
     },
-    "C-escala-evento-curto@1440": {
+    "C-escala-evento-curto@320": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:50:45.826Z",
-      "viewport": "1440x900x1",
+      "dataHora": "2026-09-11T01:06:09.719Z",
+      "viewport": "320x568x2",
       "rolagem": {
-        "altura": 10169,
+        "altura": 13395,
         "imgs": 0,
         "carregadas": 0
       },
       "data": {
-        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html",
-        "altura": 10169,
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
+        "altura": 13395,
         "fontes": {
           "status": "loaded",
           "carregadas": 33
         },
         "viewportMedido": {
-          "w": 1440,
-          "h": 900,
-          "dpr": 1
+          "w": 320,
+          "h": 568,
+          "dpr": 2
         },
-        "telas": 11.3,
-        "telas_base900_legado": 11.3,
-        "metricaV2_hsvS015": 0.4,
-        "corPerceptivel_C005": 0.4,
-        "corForte_C012": 0.4,
-        "cromaMedioPonderado": 0.009,
+        "telas": 23.6,
+        "telas_base900_legado": 14.9,
+        "metricaV2_hsvS015": 0.9,
+        "corPerceptivel_C005": 0.9,
+        "corForte_C012": 0.8,
+        "cromaMedioPonderado": 0.01,
         "cromaPicoOklch": 0.201,
         "fundos": [
           {
             "cor": "rgb(247,245,239)",
-            "pct": 67.5,
+            "pct": 65.6,
             "L": 0.97,
             "C": 0.008,
             "H": 91
           },
           {
             "cor": "rgb(232,227,217)",
-            "pct": 17.7,
+            "pct": 16.7,
             "L": 0.92,
             "C": 0.014,
             "H": 85
           },
           {
             "cor": "rgb(17,18,19)",
-            "pct": 6.9,
+            "pct": 7.3,
             "L": 0.18,
             "C": 0.003,
             "H": 248
           },
           {
             "cor": "rgb(11,11,11)",
-            "pct": 5.5,
+            "pct": 5.1,
             "L": 0.15,
             "C": 0,
             "H": 90
           },
           {
             "cor": "rgb(255,255,255)",
-            "pct": 1.2,
+            "pct": 2.8,
             "L": 1,
             "C": 0,
             "H": 90
           },
           {
             "cor": "rgb(241,238,230)",
-            "pct": 0.5,
+            "pct": 1.1,
             "L": 0.95,
             "C": 0.011,
             "H": 90
@@ -6790,18 +6765,18 @@
           "video": 0,
           "canvas": 0
         },
-        "midiaTotalPor1000": 0.2,
+        "midiaTotalPor1000": 0.15,
         "keyframes": 3,
         "nomes": [
           "rail-scroll",
           "heroUp",
           "heroLine"
         ],
-        "keyframesPor1000": 0.3,
+        "keyframesPor1000": 0.22,
         "folhasBloqueadas": 1,
         "emTransicao": 75,
-        "emTransicaoPor1000": 7.38,
-        "animacoesAtivas": 9,
+        "emTransicaoPor1000": 5.6,
+        "animacoesAtivas": 8,
         "duracoes": [
           [
             "0.6s",
@@ -6817,18 +6792,18 @@
           ]
         ],
         "tamTitulos": [
-          144,
-          72,
+          48,
+          36,
           10
         ],
         "workhorse": {
           "px": 13,
           "ocorrencias": 9
         },
-        "razaoTituloWorkhorse": 11.08,
+        "razaoTituloWorkhorse": 3.69,
         "titulosDetalhes": [
           {
-            "px": 144,
+            "px": 48,
             "elementos": 1,
             "caracteres": 16,
             "palavras": 2,
@@ -6843,10 +6818,10 @@
             "serifa": false,
             "serifa_pelaDeclarada_legado": false,
             "fontWeight": "700",
-            "lineHeightPx": "129.6px",
+            "lineHeightPx": "43.2px",
             "lineHeightRazao": 0.9,
             "lineHeightOrigem": "declarada",
-            "letterSpacing": "-5.76px",
+            "letterSpacing": "-1.92px",
             "textTransform": "none",
             "inFirstViewport": true,
             "largura_ch": 9,
@@ -6855,7 +6830,7 @@
             "vistoEmAmostras": "5/5"
           },
           {
-            "px": 72,
+            "px": 36,
             "elementos": 7,
             "caracteres": 437,
             "palavras": 62,
@@ -6875,14 +6850,14 @@
             "serifa": false,
             "serifa_pelaDeclarada_legado": false,
             "fontWeight": "600",
-            "lineHeightPx": "75.6px",
+            "lineHeightPx": "37.8px",
             "lineHeightRazao": 1.05,
             "lineHeightOrigem": "declarada",
-            "letterSpacing": "-1.44px",
+            "letterSpacing": "-0.72px",
             "textTransform": "none",
             "inFirstViewport": false,
-            "largura_ch": 24,
-            "maiorLarguraCh": 24,
+            "largura_ch": 12,
+            "maiorLarguraCh": 12,
             "fracaoContidaMin": 1,
             "vistoEmAmostras": "5/5"
           },
@@ -6909,8 +6884,8 @@
             "letterSpacing": "0.192px",
             "textTransform": "none",
             "inFirstViewport": false,
-            "largura_ch": 47,
-            "maiorLarguraCh": 47,
+            "largura_ch": 22,
+            "maiorLarguraCh": 22,
             "fracaoContidaMin": 1,
             "vistoEmAmostras": "5/5"
           }
@@ -6928,16 +6903,16 @@
         },
         "_legado": {
           "tamTitulos_semFiltro": [
-            144,
-            72,
+            48,
+            36,
             11,
             10
           ],
           "workhorse_semFiltro": {
-            "px": 14,
-            "ocorrencias": 16
+            "px": 13,
+            "ocorrencias": 19
           },
-          "razao_semFiltro": 10.29,
+          "razao_semFiltro": 3.69,
           "divergeDoCorrigido": false
         },
         "descartes": {
@@ -6958,7 +6933,7 @@
         "caixaAlta": {
           "elementos": 23,
           "caracteresTotais": 467,
-          "caracteresPor1000px": 45.92,
+          "caracteresPor1000px": 34.86,
           "semNeutralizar": 13,
           "passeNeutralizado": true,
           "amostras": 6
@@ -6978,7 +6953,7 @@
           }
         ],
         "maiorTextoRenderizado": {
-          "px": 232,
+          "px": 60,
           "tag": "div",
           "className": "footer-wordmark",
           "caracteres": 7,
@@ -6990,10 +6965,10 @@
           "fontWeight": "700",
           "textTransform": "none",
           "fracaoContida": 1,
-          "profundidadeDeRolagem": 96.6
+          "profundidadeDeRolagem": 98.5
         },
         "pontoCego": true,
-        "diferencaPx": 88,
+        "diferencaPx": 12,
         "_amostras": 5,
         "_instavel": false
       },
@@ -7001,55 +6976,55 @@
         {
           "quando": "t+4s",
           "tamTitulos": [
-            144,
-            72,
+            48,
+            36,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         },
         {
           "quando": "t+5.5s",
           "tamTitulos": [
-            144,
-            72,
+            48,
+            36,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         },
         {
           "quando": "t+7s",
           "tamTitulos": [
-            144,
-            72,
+            48,
+            36,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         },
         {
           "quando": "t+8.5s",
           "tamTitulos": [
-            144,
-            72,
+            48,
+            36,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         },
         {
           "quando": "pos-rolagem",
           "tamTitulos": [
-            144,
-            72,
+            48,
+            36,
             10
           ],
-          "maiorTexto": 232
+          "maiorTexto": 60
         }
       ],
       "variante": "C-escala-evento-curto",
-      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html"
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
     },
     "A-lp-atual@390": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:50:57.551Z",
+      "dataHora": "2026-09-11T01:06:21.187Z",
       "viewport": "390x844x2",
       "rolagem": {
         "altura": 11078,
@@ -7057,7 +7032,7 @@
         "carregadas": 0
       },
       "data": {
-        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html",
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
         "altura": 11078,
         "fontes": {
           "status": "loaded",
@@ -7380,11 +7355,11 @@
         }
       ],
       "variante": "A-lp-atual",
-      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html"
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
     },
     "B-so-escala@390": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:51:09.794Z",
+      "dataHora": "2026-09-11T01:06:33.444Z",
       "viewport": "390x844x2",
       "rolagem": {
         "altura": 12444,
@@ -7392,7 +7367,7 @@
         "carregadas": 0
       },
       "data": {
-        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html",
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
         "altura": 12444,
         "fontes": {
           "status": "loaded",
@@ -7629,7 +7604,7 @@
           "elementos": 23,
           "caracteresTotais": 467,
           "caracteresPor1000px": 37.53,
-          "semNeutralizar": 11,
+          "semNeutralizar": 13,
           "passeNeutralizado": true,
           "amostras": 6
         },
@@ -7715,11 +7690,11 @@
         }
       ],
       "variante": "B-so-escala",
-      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html"
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
     },
     "C-escala-evento-curto@390": {
       "status": "sucesso",
-      "dataHora": "2026-09-10T17:51:22.094Z",
+      "dataHora": "2026-09-11T01:06:45.749Z",
       "viewport": "390x844x2",
       "rolagem": {
         "altura": 12399,
@@ -7727,7 +7702,7 @@
         "carregadas": 0
       },
       "data": {
-        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html",
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
         "altura": 12399,
         "fontes": {
           "status": "loaded",
@@ -8050,7 +8025,3022 @@
         }
       ],
       "variante": "C-escala-evento-curto",
-      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-46-caixaAlta-determinista/wireframes/lp-final.html"
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
+    },
+    "A-lp-atual@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:06:57.224Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 10934,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
+        "altura": 10934,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 33
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 10.7,
+        "telas_base900_legado": 12.1,
+        "metricaV2_hsvS015": 0.5,
+        "corPerceptivel_C005": 0.5,
+        "corForte_C012": 0.5,
+        "cromaMedioPonderado": 0.009,
+        "cromaPicoOklch": 0.201,
+        "fundos": [
+          {
+            "cor": "rgb(247,245,239)",
+            "pct": 66.7,
+            "L": 0.97,
+            "C": 0.008,
+            "H": 91
+          },
+          {
+            "cor": "rgb(232,227,217)",
+            "pct": 14.1,
+            "L": 0.92,
+            "C": 0.014,
+            "H": 85
+          },
+          {
+            "cor": "rgb(17,18,19)",
+            "pct": 9.9,
+            "L": 0.18,
+            "C": 0.003,
+            "H": 248
+          },
+          {
+            "cor": "rgb(11,11,11)",
+            "pct": 6,
+            "L": 0.15,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 2.1,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(241,238,230)",
+            "pct": 0.5,
+            "L": 0.95,
+            "C": 0.011,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 2,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 0.18,
+        "keyframes": 3,
+        "nomes": [
+          "rail-scroll",
+          "heroUp",
+          "heroLine"
+        ],
+        "keyframesPor1000": 0.27,
+        "folhasBloqueadas": 1,
+        "emTransicao": 75,
+        "emTransicaoPor1000": 6.86,
+        "animacoesAtivas": 8,
+        "duracoes": [
+          [
+            "0.6s",
+            50
+          ],
+          [
+            "0.2s",
+            30
+          ],
+          [
+            "0.18s",
+            23
+          ]
+        ],
+        "tamTitulos": [
+          34,
+          31,
+          10
+        ],
+        "workhorse": {
+          "px": 13,
+          "ocorrencias": 9
+        },
+        "razaoTituloWorkhorse": 2.62,
+        "titulosDetalhes": [
+          {
+            "px": 34,
+            "elementos": 1,
+            "caracteres": 59,
+            "palavras": 8,
+            "textos": [
+              "CONSTRUO PRODUTOS DIGITAIS E LIDERO PROJETOS DE TECNOLOGIA."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "35.1437px",
+            "lineHeightRazao": 1.03,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1.01376px",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 32,
+            "maiorLarguraCh": 32,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 31,
+            "elementos": 7,
+            "caracteres": 437,
+            "palavras": 62,
+            "textos": [
+              "Transformando pesquisa hidrológica nacional em uma ferramenta digital utilizável.",
+              "Levando um projeto de cliente dos requisitos à produção.",
+              "Conectando necessidades do cliente, decisões de design e desenvolvimento.",
+              "Testando quando machine learning quântico realmente faz diferença.",
+              "De software científico à pesquisa em IA aplicada.",
+              "O que quero entender a seguir."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "36.2496px",
+            "lineHeightRazao": 1.17,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.768px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 35,
+            "maiorLarguraCh": 35,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 10,
+            "elementos": 2,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "NAVEGAÇÃO",
+              "CONTATO"
+            ],
+            "fontFamily": "\"IBM Plex Mono\", monospace",
+            "familiaEfetiva": "IBM Plex Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ibm plex mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "14.4px",
+            "lineHeightRazao": 1.44,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "1.152px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 49,
+            "maiorLarguraCh": 49,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 13,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "19.68px",
+          "lineHeightRazao": 1.51,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 42
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            34,
+            31,
+            11,
+            10
+          ],
+          "workhorse_semFiltro": {
+            "px": 13,
+            "ocorrencias": 19
+          },
+          "razao_semFiltro": 2.62,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS REAIS\nBREAST CANCER WISCONSIN"
+            },
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS SINTÉTICOS\nQISKIT AD_HOC_DATA"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 89,
+          "caracteresTotais": 1419,
+          "caracteresPor1000px": 129.78,
+          "semNeutralizar": 48,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 11
+          },
+          {
+            "familia": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 8
+          },
+          {
+            "familia": "\"IBM Plex Mono\", monospace",
+            "contagem": 7
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 143,
+          "tag": "div",
+          "className": "footer-wordmark",
+          "caracteres": 7,
+          "palavras": 1,
+          "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Instrument Sans",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 97.6
+        },
+        "pontoCego": true,
+        "diferencaPx": 109,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            34,
+            31,
+            10
+          ],
+          "maiorTexto": 143
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            34,
+            31,
+            10
+          ],
+          "maiorTexto": 143
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            34,
+            31,
+            10
+          ],
+          "maiorTexto": 143
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            34,
+            31,
+            10
+          ],
+          "maiorTexto": 143
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            34,
+            31,
+            10
+          ],
+          "maiorTexto": 143
+        }
+      ],
+      "variante": "A-lp-atual",
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
+    },
+    "B-so-escala@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:07:09.430Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 11586,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
+        "altura": 11586,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 33
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 11.3,
+        "telas_base900_legado": 12.9,
+        "metricaV2_hsvS015": 0.5,
+        "corPerceptivel_C005": 0.5,
+        "corForte_C012": 0.4,
+        "cromaMedioPonderado": 0.009,
+        "cromaPicoOklch": 0.201,
+        "fundos": [
+          {
+            "cor": "rgb(247,245,239)",
+            "pct": 66.3,
+            "L": 0.97,
+            "C": 0.008,
+            "H": 91
+          },
+          {
+            "cor": "rgb(232,227,217)",
+            "pct": 14.7,
+            "L": 0.92,
+            "C": 0.014,
+            "H": 85
+          },
+          {
+            "cor": "rgb(17,18,19)",
+            "pct": 9.8,
+            "L": 0.18,
+            "C": 0.003,
+            "H": 248
+          },
+          {
+            "cor": "rgb(11,11,11)",
+            "pct": 6,
+            "L": 0.15,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 2.1,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(241,238,230)",
+            "pct": 0.5,
+            "L": 0.95,
+            "C": 0.011,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 2,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 0.17,
+        "keyframes": 3,
+        "nomes": [
+          "rail-scroll",
+          "heroUp",
+          "heroLine"
+        ],
+        "keyframesPor1000": 0.26,
+        "folhasBloqueadas": 1,
+        "emTransicao": 75,
+        "emTransicaoPor1000": 6.47,
+        "animacoesAtivas": 8,
+        "duracoes": [
+          [
+            "0.6s",
+            50
+          ],
+          [
+            "0.2s",
+            30
+          ],
+          [
+            "0.18s",
+            23
+          ]
+        ],
+        "tamTitulos": [
+          77,
+          38,
+          10
+        ],
+        "workhorse": {
+          "px": 13,
+          "ocorrencias": 9
+        },
+        "razaoTituloWorkhorse": 5.92,
+        "titulosDetalhes": [
+          {
+            "px": 77,
+            "elementos": 1,
+            "caracteres": 59,
+            "palavras": 8,
+            "textos": [
+              "Construo produtos digitais e lidero projetos de tecnologia."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "69.12px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-3.072px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 14,
+            "maiorLarguraCh": 14,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 38,
+            "elementos": 7,
+            "caracteres": 437,
+            "palavras": 62,
+            "textos": [
+              "Transformando pesquisa hidrológica nacional em uma ferramenta digital utilizável.",
+              "Levando um projeto de cliente dos requisitos à produção.",
+              "Conectando necessidades do cliente, decisões de design e desenvolvimento.",
+              "Testando quando machine learning quântico realmente faz diferença.",
+              "De software científico à pesquisa em IA aplicada.",
+              "O que quero entender a seguir."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "40.32px",
+            "lineHeightRazao": 1.06,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.768px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 28,
+            "maiorLarguraCh": 28,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 10,
+            "elementos": 2,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "Navegação",
+              "Contato"
+            ],
+            "fontFamily": "\"IBM Plex Mono\", monospace",
+            "familiaEfetiva": "IBM Plex Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ibm plex mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "14.4px",
+            "lineHeightRazao": 1.44,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "0.192px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 57,
+            "maiorLarguraCh": 57,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 13,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "19.68px",
+          "lineHeightRazao": 1.51,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 42
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            77,
+            38,
+            11,
+            10
+          ],
+          "workhorse_semFiltro": {
+            "px": 13,
+            "ocorrencias": 19
+          },
+          "razao_semFiltro": 5.92,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS REAIS\nBreast Cancer Wisconsin"
+            },
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS SINTÉTICOS\nQiskit ad_hoc_data"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 23,
+          "caracteresTotais": 467,
+          "caracteresPor1000px": 40.31,
+          "semNeutralizar": 13,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 11
+          },
+          {
+            "familia": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 8
+          },
+          {
+            "familia": "\"IBM Plex Mono\", monospace",
+            "contagem": 7
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 143,
+          "tag": "div",
+          "className": "footer-wordmark",
+          "caracteres": 7,
+          "palavras": 1,
+          "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Instrument Sans",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 97.8
+        },
+        "pontoCego": true,
+        "diferencaPx": 66,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            77,
+            38,
+            10
+          ],
+          "maiorTexto": 143
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            77,
+            38,
+            10
+          ],
+          "maiorTexto": 143
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            77,
+            38,
+            10
+          ],
+          "maiorTexto": 143
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            77,
+            38,
+            10
+          ],
+          "maiorTexto": 143
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            77,
+            38,
+            10
+          ],
+          "maiorTexto": 143
+        }
+      ],
+      "variante": "B-so-escala",
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
+    },
+    "C-escala-evento-curto@768": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:07:21.654Z",
+      "viewport": "768x1024x2",
+      "rolagem": {
+        "altura": 11532,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
+        "altura": 11532,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 33
+        },
+        "viewportMedido": {
+          "w": 768,
+          "h": 1024,
+          "dpr": 2
+        },
+        "telas": 11.3,
+        "telas_base900_legado": 12.8,
+        "metricaV2_hsvS015": 0.5,
+        "corPerceptivel_C005": 0.5,
+        "corForte_C012": 0.4,
+        "cromaMedioPonderado": 0.009,
+        "cromaPicoOklch": 0.201,
+        "fundos": [
+          {
+            "cor": "rgb(247,245,239)",
+            "pct": 66.2,
+            "L": 0.97,
+            "C": 0.008,
+            "H": 91
+          },
+          {
+            "cor": "rgb(232,227,217)",
+            "pct": 14.8,
+            "L": 0.92,
+            "C": 0.014,
+            "H": 85
+          },
+          {
+            "cor": "rgb(17,18,19)",
+            "pct": 9.8,
+            "L": 0.18,
+            "C": 0.003,
+            "H": 248
+          },
+          {
+            "cor": "rgb(11,11,11)",
+            "pct": 6,
+            "L": 0.15,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 2.1,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(241,238,230)",
+            "pct": 0.5,
+            "L": 0.95,
+            "C": 0.011,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 2,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 0.17,
+        "keyframes": 3,
+        "nomes": [
+          "rail-scroll",
+          "heroUp",
+          "heroLine"
+        ],
+        "keyframesPor1000": 0.26,
+        "folhasBloqueadas": 1,
+        "emTransicao": 75,
+        "emTransicaoPor1000": 6.5,
+        "animacoesAtivas": 8,
+        "duracoes": [
+          [
+            "0.6s",
+            50
+          ],
+          [
+            "0.2s",
+            30
+          ],
+          [
+            "0.18s",
+            23
+          ]
+        ],
+        "tamTitulos": [
+          77,
+          38,
+          10
+        ],
+        "workhorse": {
+          "px": 13,
+          "ocorrencias": 9
+        },
+        "razaoTituloWorkhorse": 5.92,
+        "titulosDetalhes": [
+          {
+            "px": 77,
+            "elementos": 1,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "AUGUSTO\nMENCHACA"
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "69.12px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-3.072px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 14,
+            "maiorLarguraCh": 14,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 38,
+            "elementos": 7,
+            "caracteres": 437,
+            "palavras": 62,
+            "textos": [
+              "Transformando pesquisa hidrológica nacional em uma ferramenta digital utilizável.",
+              "Levando um projeto de cliente dos requisitos à produção.",
+              "Conectando necessidades do cliente, decisões de design e desenvolvimento.",
+              "Testando quando machine learning quântico realmente faz diferença.",
+              "De software científico à pesquisa em IA aplicada.",
+              "O que quero entender a seguir."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "40.32px",
+            "lineHeightRazao": 1.06,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.768px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 28,
+            "maiorLarguraCh": 28,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 10,
+            "elementos": 2,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "Navegação",
+              "Contato"
+            ],
+            "fontFamily": "\"IBM Plex Mono\", monospace",
+            "familiaEfetiva": "IBM Plex Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ibm plex mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "14.4px",
+            "lineHeightRazao": 1.44,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "0.192px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 57,
+            "maiorLarguraCh": 57,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 13,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "19.68px",
+          "lineHeightRazao": 1.51,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 42
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            77,
+            38,
+            11,
+            10
+          ],
+          "workhorse_semFiltro": {
+            "px": 13,
+            "ocorrencias": 19
+          },
+          "razao_semFiltro": 5.92,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS REAIS\nBreast Cancer Wisconsin"
+            },
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS SINTÉTICOS\nQiskit ad_hoc_data"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 23,
+          "caracteresTotais": 467,
+          "caracteresPor1000px": 40.5,
+          "semNeutralizar": 13,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 12
+          },
+          {
+            "familia": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 8
+          },
+          {
+            "familia": "\"IBM Plex Mono\", monospace",
+            "contagem": 7
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 143,
+          "tag": "div",
+          "className": "footer-wordmark",
+          "caracteres": 7,
+          "palavras": 1,
+          "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Instrument Sans",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 97.8
+        },
+        "pontoCego": true,
+        "diferencaPx": 66,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            77,
+            38,
+            10
+          ],
+          "maiorTexto": 143
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            77,
+            38,
+            10
+          ],
+          "maiorTexto": 143
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            77,
+            38,
+            10
+          ],
+          "maiorTexto": 143
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            77,
+            38,
+            10
+          ],
+          "maiorTexto": 143
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            77,
+            38,
+            10
+          ],
+          "maiorTexto": 143
+        }
+      ],
+      "variante": "C-escala-evento-curto",
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
+    },
+    "A-lp-atual@1024": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:07:32.799Z",
+      "viewport": "1024x768x1",
+      "rolagem": {
+        "altura": 7762,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
+        "altura": 7762,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 33
+        },
+        "viewportMedido": {
+          "w": 1024,
+          "h": 768,
+          "dpr": 1
+        },
+        "telas": 10.1,
+        "telas_base900_legado": 8.6,
+        "metricaV2_hsvS015": 0.7,
+        "corPerceptivel_C005": 0.7,
+        "corForte_C012": 0.6,
+        "cromaMedioPonderado": 0.009,
+        "cromaPicoOklch": 0.201,
+        "fundos": [
+          {
+            "cor": "rgb(247,245,239)",
+            "pct": 66.9,
+            "L": 0.97,
+            "C": 0.008,
+            "H": 91
+          },
+          {
+            "cor": "rgb(232,227,217)",
+            "pct": 15.4,
+            "L": 0.92,
+            "C": 0.014,
+            "H": 85
+          },
+          {
+            "cor": "rgb(17,18,19)",
+            "pct": 8,
+            "L": 0.18,
+            "C": 0.003,
+            "H": 248
+          },
+          {
+            "cor": "rgb(11,11,11)",
+            "pct": 5.6,
+            "L": 0.15,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 2.2,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(241,238,230)",
+            "pct": 0.9,
+            "L": 0.95,
+            "C": 0.011,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 2,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 0.26,
+        "keyframes": 3,
+        "nomes": [
+          "rail-scroll",
+          "heroUp",
+          "heroLine"
+        ],
+        "keyframesPor1000": 0.39,
+        "folhasBloqueadas": 1,
+        "emTransicao": 75,
+        "emTransicaoPor1000": 9.66,
+        "animacoesAtivas": 9,
+        "duracoes": [
+          [
+            "0.6s",
+            50
+          ],
+          [
+            "0.2s",
+            30
+          ],
+          [
+            "0.18s",
+            23
+          ]
+        ],
+        "tamTitulos": [
+          45,
+          34,
+          10
+        ],
+        "workhorse": {
+          "px": 13,
+          "ocorrencias": 9
+        },
+        "razaoTituloWorkhorse": 3.46,
+        "titulosDetalhes": [
+          {
+            "px": 45,
+            "elementos": 1,
+            "caracteres": 59,
+            "palavras": 8,
+            "textos": [
+              "CONSTRUO PRODUTOS DIGITAIS E LIDERO PROJETOS DE TECNOLOGIA."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "46.8582px",
+            "lineHeightRazao": 1.04,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1.35168px",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 19,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 34,
+            "elementos": 7,
+            "caracteres": 437,
+            "palavras": 62,
+            "textos": [
+              "Transformando pesquisa hidrológica nacional em uma ferramenta digital utilizável.",
+              "Levando um projeto de cliente dos requisitos à produção.",
+              "Conectando necessidades do cliente, decisões de design e desenvolvimento.",
+              "Testando quando machine learning quântico realmente faz diferença.",
+              "De software científico à pesquisa em IA aplicada.",
+              "O que quero entender a seguir."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "40.592px",
+            "lineHeightRazao": 1.19,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.86px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 25,
+            "maiorLarguraCh": 42,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 10,
+            "elementos": 2,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "NAVEGAÇÃO",
+              "CONTATO"
+            ],
+            "fontFamily": "\"IBM Plex Mono\", monospace",
+            "familiaEfetiva": "IBM Plex Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ibm plex mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "14.4px",
+            "lineHeightRazao": 1.44,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "1.152px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 33,
+            "maiorLarguraCh": 33,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 13,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "19.68px",
+          "lineHeightRazao": 1.51,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 34
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            45,
+            34,
+            11,
+            10
+          ],
+          "workhorse_semFiltro": {
+            "px": 14,
+            "ocorrencias": 16
+          },
+          "razao_semFiltro": 3.21,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS REAIS\nBREAST CANCER WISCONSIN"
+            },
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS SINTÉTICOS\nQISKIT AD_HOC_DATA"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 96,
+          "caracteresTotais": 1513,
+          "caracteresPor1000px": 194.92,
+          "semNeutralizar": 61,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 16
+          },
+          {
+            "familia": "\"IBM Plex Mono\", monospace",
+            "contagem": 15
+          },
+          {
+            "familia": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 8
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 190,
+          "tag": "div",
+          "className": "footer-wordmark",
+          "caracteres": 7,
+          "palavras": 1,
+          "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Instrument Sans",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 96.1
+        },
+        "pontoCego": true,
+        "diferencaPx": 145,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            45,
+            34,
+            10
+          ],
+          "maiorTexto": 190
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            45,
+            34,
+            10
+          ],
+          "maiorTexto": 190
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            45,
+            34,
+            10
+          ],
+          "maiorTexto": 190
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            45,
+            34,
+            10
+          ],
+          "maiorTexto": 190
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            45,
+            34,
+            10
+          ],
+          "maiorTexto": 190
+        }
+      ],
+      "variante": "A-lp-atual",
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
+    },
+    "B-so-escala@1024": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:07:44.571Z",
+      "viewport": "1024x768x1",
+      "rolagem": {
+        "altura": 8826,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
+        "altura": 8826,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 33
+        },
+        "viewportMedido": {
+          "w": 1024,
+          "h": 768,
+          "dpr": 1
+        },
+        "telas": 11.5,
+        "telas_base900_legado": 9.8,
+        "metricaV2_hsvS015": 0.6,
+        "corPerceptivel_C005": 0.6,
+        "corForte_C012": 0.6,
+        "cromaMedioPonderado": 0.009,
+        "cromaPicoOklch": 0.201,
+        "fundos": [
+          {
+            "cor": "rgb(247,245,239)",
+            "pct": 66.9,
+            "L": 0.97,
+            "C": 0.008,
+            "H": 91
+          },
+          {
+            "cor": "rgb(232,227,217)",
+            "pct": 16.6,
+            "L": 0.92,
+            "C": 0.014,
+            "H": 85
+          },
+          {
+            "cor": "rgb(17,18,19)",
+            "pct": 7.2,
+            "L": 0.18,
+            "C": 0.003,
+            "H": 248
+          },
+          {
+            "cor": "rgb(11,11,11)",
+            "pct": 5.3,
+            "L": 0.15,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 2.1,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(241,238,230)",
+            "pct": 0.9,
+            "L": 0.95,
+            "C": 0.011,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 2,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 0.23,
+        "keyframes": 3,
+        "nomes": [
+          "rail-scroll",
+          "heroUp",
+          "heroLine"
+        ],
+        "keyframesPor1000": 0.34,
+        "folhasBloqueadas": 1,
+        "emTransicao": 75,
+        "emTransicaoPor1000": 8.5,
+        "animacoesAtivas": 9,
+        "duracoes": [
+          [
+            "0.6s",
+            50
+          ],
+          [
+            "0.2s",
+            30
+          ],
+          [
+            "0.18s",
+            23
+          ]
+        ],
+        "tamTitulos": [
+          102,
+          51,
+          10
+        ],
+        "workhorse": {
+          "px": 13,
+          "ocorrencias": 9
+        },
+        "razaoTituloWorkhorse": 7.85,
+        "titulosDetalhes": [
+          {
+            "px": 102,
+            "elementos": 1,
+            "caracteres": 59,
+            "palavras": 8,
+            "textos": [
+              "Construo produtos digitais e lidero projetos de tecnologia."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "92.16px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-4.096px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 51,
+            "elementos": 7,
+            "caracteres": 437,
+            "palavras": 62,
+            "textos": [
+              "Transformando pesquisa hidrológica nacional em uma ferramenta digital utilizável.",
+              "Levando um projeto de cliente dos requisitos à produção.",
+              "Conectando necessidades do cliente, decisões de design e desenvolvimento.",
+              "Testando quando machine learning quântico realmente faz diferença.",
+              "De software científico à pesquisa em IA aplicada.",
+              "O que quero entender a seguir."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "53.76px",
+            "lineHeightRazao": 1.05,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1.024px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 25,
+            "maiorLarguraCh": 28,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 10,
+            "elementos": 2,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "Navegação",
+              "Contato"
+            ],
+            "fontFamily": "\"IBM Plex Mono\", monospace",
+            "familiaEfetiva": "IBM Plex Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ibm plex mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "14.4px",
+            "lineHeightRazao": 1.44,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "0.192px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 38,
+            "maiorLarguraCh": 38,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 13,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "19.68px",
+          "lineHeightRazao": 1.51,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 34
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            102,
+            51,
+            11,
+            10
+          ],
+          "workhorse_semFiltro": {
+            "px": 14,
+            "ocorrencias": 16
+          },
+          "razao_semFiltro": 7.29,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS REAIS\nBreast Cancer Wisconsin"
+            },
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS SINTÉTICOS\nQiskit ad_hoc_data"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 23,
+          "caracteresTotais": 467,
+          "caracteresPor1000px": 52.91,
+          "semNeutralizar": 13,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 11
+          },
+          {
+            "familia": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 8
+          },
+          {
+            "familia": "\"IBM Plex Mono\", monospace",
+            "contagem": 7
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 190,
+          "tag": "div",
+          "className": "footer-wordmark",
+          "caracteres": 7,
+          "palavras": 1,
+          "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Instrument Sans",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 96.5
+        },
+        "pontoCego": true,
+        "diferencaPx": 88,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            102,
+            51,
+            10
+          ],
+          "maiorTexto": 190
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            102,
+            51,
+            10
+          ],
+          "maiorTexto": 190
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            102,
+            51,
+            10
+          ],
+          "maiorTexto": 190
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            102,
+            51,
+            10
+          ],
+          "maiorTexto": 190
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            102,
+            51,
+            10
+          ],
+          "maiorTexto": 190
+        }
+      ],
+      "variante": "B-so-escala",
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
+    },
+    "C-escala-evento-curto@1024": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:07:56.345Z",
+      "viewport": "1024x768x1",
+      "rolagem": {
+        "altura": 8541,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
+        "altura": 8541,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 33
+        },
+        "viewportMedido": {
+          "w": 1024,
+          "h": 768,
+          "dpr": 1
+        },
+        "telas": 11.1,
+        "telas_base900_legado": 9.5,
+        "metricaV2_hsvS015": 0.7,
+        "corPerceptivel_C005": 0.7,
+        "corForte_C012": 0.6,
+        "cromaMedioPonderado": 0.009,
+        "cromaPicoOklch": 0.201,
+        "fundos": [
+          {
+            "cor": "rgb(247,245,239)",
+            "pct": 66.4,
+            "L": 0.97,
+            "C": 0.008,
+            "H": 91
+          },
+          {
+            "cor": "rgb(232,227,217)",
+            "pct": 16.9,
+            "L": 0.92,
+            "C": 0.014,
+            "H": 85
+          },
+          {
+            "cor": "rgb(17,18,19)",
+            "pct": 7.3,
+            "L": 0.18,
+            "C": 0.003,
+            "H": 248
+          },
+          {
+            "cor": "rgb(11,11,11)",
+            "pct": 5.4,
+            "L": 0.15,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 2.1,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(241,238,230)",
+            "pct": 0.9,
+            "L": 0.95,
+            "C": 0.011,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 2,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 0.23,
+        "keyframes": 3,
+        "nomes": [
+          "rail-scroll",
+          "heroUp",
+          "heroLine"
+        ],
+        "keyframesPor1000": 0.35,
+        "folhasBloqueadas": 1,
+        "emTransicao": 75,
+        "emTransicaoPor1000": 8.78,
+        "animacoesAtivas": 9,
+        "duracoes": [
+          [
+            "0.6s",
+            50
+          ],
+          [
+            "0.2s",
+            30
+          ],
+          [
+            "0.18s",
+            23
+          ]
+        ],
+        "tamTitulos": [
+          102,
+          51,
+          10
+        ],
+        "workhorse": {
+          "px": 13,
+          "ocorrencias": 9
+        },
+        "razaoTituloWorkhorse": 7.85,
+        "titulosDetalhes": [
+          {
+            "px": 102,
+            "elementos": 1,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "AUGUSTO\nMENCHACA"
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "92.16px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-4.096px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 51,
+            "elementos": 7,
+            "caracteres": 437,
+            "palavras": 62,
+            "textos": [
+              "Transformando pesquisa hidrológica nacional em uma ferramenta digital utilizável.",
+              "Levando um projeto de cliente dos requisitos à produção.",
+              "Conectando necessidades do cliente, decisões de design e desenvolvimento.",
+              "Testando quando machine learning quântico realmente faz diferença.",
+              "De software científico à pesquisa em IA aplicada.",
+              "O que quero entender a seguir."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "53.76px",
+            "lineHeightRazao": 1.05,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1.024px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 25,
+            "maiorLarguraCh": 28,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 10,
+            "elementos": 2,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "Navegação",
+              "Contato"
+            ],
+            "fontFamily": "\"IBM Plex Mono\", monospace",
+            "familiaEfetiva": "IBM Plex Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ibm plex mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "14.4px",
+            "lineHeightRazao": 1.44,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "0.192px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 38,
+            "maiorLarguraCh": 38,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 13,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "19.68px",
+          "lineHeightRazao": 1.51,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 34
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            102,
+            51,
+            11,
+            10
+          ],
+          "workhorse_semFiltro": {
+            "px": 14,
+            "ocorrencias": 16
+          },
+          "razao_semFiltro": 7.29,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS REAIS\nBreast Cancer Wisconsin"
+            },
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS SINTÉTICOS\nQiskit ad_hoc_data"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 23,
+          "caracteresTotais": 467,
+          "caracteresPor1000px": 54.68,
+          "semNeutralizar": 13,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 12
+          },
+          {
+            "familia": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 8
+          },
+          {
+            "familia": "\"IBM Plex Mono\", monospace",
+            "contagem": 7
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 190,
+          "tag": "div",
+          "className": "footer-wordmark",
+          "caracteres": 7,
+          "palavras": 1,
+          "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Instrument Sans",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 96.4
+        },
+        "pontoCego": true,
+        "diferencaPx": 88,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            102,
+            51,
+            10
+          ],
+          "maiorTexto": 190
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            102,
+            51,
+            10
+          ],
+          "maiorTexto": 190
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            102,
+            51,
+            10
+          ],
+          "maiorTexto": 190
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            102,
+            51,
+            10
+          ],
+          "maiorTexto": 190
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            102,
+            51,
+            10
+          ],
+          "maiorTexto": 190
+        }
+      ],
+      "variante": "C-escala-evento-curto",
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
+    },
+    "A-lp-atual@1440": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:08:07.351Z",
+      "viewport": "1440x900x1",
+      "rolagem": {
+        "altura": 8350,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
+        "altura": 8350,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 33
+        },
+        "viewportMedido": {
+          "w": 1440,
+          "h": 900,
+          "dpr": 1
+        },
+        "telas": 9.3,
+        "telas_base900_legado": 9.3,
+        "metricaV2_hsvS015": 0.5,
+        "corPerceptivel_C005": 0.5,
+        "corForte_C012": 0.4,
+        "cromaMedioPonderado": 0.009,
+        "cromaPicoOklch": 0.201,
+        "fundos": [
+          {
+            "cor": "rgb(247,245,239)",
+            "pct": 68.5,
+            "L": 0.97,
+            "C": 0.008,
+            "H": 91
+          },
+          {
+            "cor": "rgb(232,227,217)",
+            "pct": 15,
+            "L": 0.92,
+            "C": 0.014,
+            "H": 85
+          },
+          {
+            "cor": "rgb(17,18,19)",
+            "pct": 7.7,
+            "L": 0.18,
+            "C": 0.003,
+            "H": 248
+          },
+          {
+            "cor": "rgb(11,11,11)",
+            "pct": 6,
+            "L": 0.15,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 1.5,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(241,238,230)",
+            "pct": 0.6,
+            "L": 0.95,
+            "C": 0.011,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 2,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 0.24,
+        "keyframes": 3,
+        "nomes": [
+          "rail-scroll",
+          "heroUp",
+          "heroLine"
+        ],
+        "keyframesPor1000": 0.36,
+        "folhasBloqueadas": 1,
+        "emTransicao": 75,
+        "emTransicaoPor1000": 8.98,
+        "animacoesAtivas": 9,
+        "duracoes": [
+          [
+            "0.6s",
+            50
+          ],
+          [
+            "0.2s",
+            30
+          ],
+          [
+            "0.18s",
+            23
+          ]
+        ],
+        "tamTitulos": [
+          46,
+          34,
+          10
+        ],
+        "workhorse": {
+          "px": 13,
+          "ocorrencias": 9
+        },
+        "razaoTituloWorkhorse": 3.54,
+        "titulosDetalhes": [
+          {
+            "px": 46,
+            "elementos": 1,
+            "caracteres": 59,
+            "palavras": 8,
+            "textos": [
+              "CONSTRUO PRODUTOS DIGITAIS E LIDERO PROJETOS DE TECNOLOGIA."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "48.256px",
+            "lineHeightRazao": 1.05,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1.392px",
+            "textTransform": "uppercase",
+            "inFirstViewport": true,
+            "largura_ch": 19,
+            "maiorLarguraCh": 19,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 34,
+            "elementos": 7,
+            "caracteres": 437,
+            "palavras": 62,
+            "textos": [
+              "Transformando pesquisa hidrológica nacional em uma ferramenta digital utilizável.",
+              "Levando um projeto de cliente dos requisitos à produção.",
+              "Conectando necessidades do cliente, decisões de design e desenvolvimento.",
+              "Testando quando machine learning quântico realmente faz diferença.",
+              "De software científico à pesquisa em IA aplicada.",
+              "O que quero entender a seguir."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "40.592px",
+            "lineHeightRazao": 1.19,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.86px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 25,
+            "maiorLarguraCh": 51,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 10,
+            "elementos": 2,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "NAVEGAÇÃO",
+              "CONTATO"
+            ],
+            "fontFamily": "\"IBM Plex Mono\", monospace",
+            "familiaEfetiva": "IBM Plex Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ibm plex mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "14.4px",
+            "lineHeightRazao": 1.44,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "1.152px",
+            "textTransform": "uppercase",
+            "inFirstViewport": false,
+            "largura_ch": 40,
+            "maiorLarguraCh": 40,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 13,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "19.68px",
+          "lineHeightRazao": 1.51,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 34
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            46,
+            34,
+            11,
+            10
+          ],
+          "workhorse_semFiltro": {
+            "px": 14,
+            "ocorrencias": 16
+          },
+          "razao_semFiltro": 3.29,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS REAIS\nBREAST CANCER WISCONSIN"
+            },
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS SINTÉTICOS\nQISKIT AD_HOC_DATA"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 96,
+          "caracteresTotais": 1513,
+          "caracteresPor1000px": 181.2,
+          "semNeutralizar": 55,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 11
+          },
+          {
+            "familia": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 8
+          },
+          {
+            "familia": "\"IBM Plex Mono\", monospace",
+            "contagem": 7
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 232,
+          "tag": "div",
+          "className": "footer-wordmark",
+          "caracteres": 7,
+          "palavras": 1,
+          "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Instrument Sans",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 95.9
+        },
+        "pontoCego": true,
+        "diferencaPx": 186,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            46,
+            34,
+            10
+          ],
+          "maiorTexto": 232
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            46,
+            34,
+            10
+          ],
+          "maiorTexto": 232
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            46,
+            34,
+            10
+          ],
+          "maiorTexto": 232
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            46,
+            34,
+            10
+          ],
+          "maiorTexto": 232
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            46,
+            34,
+            10
+          ],
+          "maiorTexto": 232
+        }
+      ],
+      "variante": "A-lp-atual",
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
+    },
+    "B-so-escala@1440": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:08:19.399Z",
+      "viewport": "1440x900x1",
+      "rolagem": {
+        "altura": 10604,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
+        "altura": 10604,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 33
+        },
+        "viewportMedido": {
+          "w": 1440,
+          "h": 900,
+          "dpr": 1
+        },
+        "telas": 11.8,
+        "telas_base900_legado": 11.8,
+        "metricaV2_hsvS015": 0.4,
+        "corPerceptivel_C005": 0.4,
+        "corForte_C012": 0.4,
+        "cromaMedioPonderado": 0.009,
+        "cromaPicoOklch": 0.201,
+        "fundos": [
+          {
+            "cor": "rgb(247,245,239)",
+            "pct": 68.1,
+            "L": 0.97,
+            "C": 0.008,
+            "H": 91
+          },
+          {
+            "cor": "rgb(232,227,217)",
+            "pct": 17.3,
+            "L": 0.92,
+            "C": 0.014,
+            "H": 85
+          },
+          {
+            "cor": "rgb(17,18,19)",
+            "pct": 6.8,
+            "L": 0.18,
+            "C": 0.003,
+            "H": 248
+          },
+          {
+            "cor": "rgb(11,11,11)",
+            "pct": 5.4,
+            "L": 0.15,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 1.3,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(241,238,230)",
+            "pct": 0.5,
+            "L": 0.95,
+            "C": 0.011,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 2,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 0.19,
+        "keyframes": 3,
+        "nomes": [
+          "rail-scroll",
+          "heroUp",
+          "heroLine"
+        ],
+        "keyframesPor1000": 0.28,
+        "folhasBloqueadas": 1,
+        "emTransicao": 75,
+        "emTransicaoPor1000": 7.07,
+        "animacoesAtivas": 9,
+        "duracoes": [
+          [
+            "0.6s",
+            50
+          ],
+          [
+            "0.2s",
+            30
+          ],
+          [
+            "0.18s",
+            23
+          ]
+        ],
+        "tamTitulos": [
+          144,
+          72,
+          10
+        ],
+        "workhorse": {
+          "px": 13,
+          "ocorrencias": 9
+        },
+        "razaoTituloWorkhorse": 11.08,
+        "titulosDetalhes": [
+          {
+            "px": 144,
+            "elementos": 1,
+            "caracteres": 59,
+            "palavras": 8,
+            "textos": [
+              "Construo produtos digitais e lidero projetos de tecnologia."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "129.6px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-5.76px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 8,
+            "maiorLarguraCh": 8,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 72,
+            "elementos": 7,
+            "caracteres": 437,
+            "palavras": 62,
+            "textos": [
+              "Transformando pesquisa hidrológica nacional em uma ferramenta digital utilizável.",
+              "Levando um projeto de cliente dos requisitos à produção.",
+              "Conectando necessidades do cliente, decisões de design e desenvolvimento.",
+              "Testando quando machine learning quântico realmente faz diferença.",
+              "De software científico à pesquisa em IA aplicada.",
+              "O que quero entender a seguir."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "75.6px",
+            "lineHeightRazao": 1.05,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1.44px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 24,
+            "maiorLarguraCh": 24,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 10,
+            "elementos": 2,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "Navegação",
+              "Contato"
+            ],
+            "fontFamily": "\"IBM Plex Mono\", monospace",
+            "familiaEfetiva": "IBM Plex Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ibm plex mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "14.4px",
+            "lineHeightRazao": 1.44,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "0.192px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 47,
+            "maiorLarguraCh": 47,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 13,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "19.68px",
+          "lineHeightRazao": 1.51,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 34
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            144,
+            72,
+            11,
+            10
+          ],
+          "workhorse_semFiltro": {
+            "px": 14,
+            "ocorrencias": 16
+          },
+          "razao_semFiltro": 10.29,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS REAIS\nBreast Cancer Wisconsin"
+            },
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS SINTÉTICOS\nQiskit ad_hoc_data"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 23,
+          "caracteresTotais": 467,
+          "caracteresPor1000px": 44.04,
+          "semNeutralizar": 13,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 11
+          },
+          {
+            "familia": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 8
+          },
+          {
+            "familia": "\"IBM Plex Mono\", monospace",
+            "contagem": 7
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 232,
+          "tag": "div",
+          "className": "footer-wordmark",
+          "caracteres": 7,
+          "palavras": 1,
+          "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Instrument Sans",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 96.7
+        },
+        "pontoCego": true,
+        "diferencaPx": 88,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            144,
+            72,
+            10
+          ],
+          "maiorTexto": 232
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            144,
+            72,
+            10
+          ],
+          "maiorTexto": 232
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            144,
+            72,
+            10
+          ],
+          "maiorTexto": 232
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            144,
+            72,
+            10
+          ],
+          "maiorTexto": 232
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            144,
+            72,
+            10
+          ],
+          "maiorTexto": 232
+        }
+      ],
+      "variante": "B-so-escala",
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
+    },
+    "C-escala-evento-curto@1440": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T01:08:31.227Z",
+      "viewport": "1440x900x1",
+      "rolagem": {
+        "altura": 10169,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
+        "altura": 10169,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 33
+        },
+        "viewportMedido": {
+          "w": 1440,
+          "h": 900,
+          "dpr": 1
+        },
+        "telas": 11.3,
+        "telas_base900_legado": 11.3,
+        "metricaV2_hsvS015": 0.4,
+        "corPerceptivel_C005": 0.4,
+        "corForte_C012": 0.4,
+        "cromaMedioPonderado": 0.009,
+        "cromaPicoOklch": 0.201,
+        "fundos": [
+          {
+            "cor": "rgb(247,245,239)",
+            "pct": 67.5,
+            "L": 0.97,
+            "C": 0.008,
+            "H": 91
+          },
+          {
+            "cor": "rgb(232,227,217)",
+            "pct": 17.7,
+            "L": 0.92,
+            "C": 0.014,
+            "H": 85
+          },
+          {
+            "cor": "rgb(17,18,19)",
+            "pct": 6.9,
+            "L": 0.18,
+            "C": 0.003,
+            "H": 248
+          },
+          {
+            "cor": "rgb(11,11,11)",
+            "pct": 5.5,
+            "L": 0.15,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 1.2,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(241,238,230)",
+            "pct": 0.5,
+            "L": 0.95,
+            "C": 0.011,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 2,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 0.2,
+        "keyframes": 3,
+        "nomes": [
+          "rail-scroll",
+          "heroUp",
+          "heroLine"
+        ],
+        "keyframesPor1000": 0.3,
+        "folhasBloqueadas": 1,
+        "emTransicao": 75,
+        "emTransicaoPor1000": 7.38,
+        "animacoesAtivas": 9,
+        "duracoes": [
+          [
+            "0.6s",
+            50
+          ],
+          [
+            "0.2s",
+            30
+          ],
+          [
+            "0.18s",
+            23
+          ]
+        ],
+        "tamTitulos": [
+          144,
+          72,
+          10
+        ],
+        "workhorse": {
+          "px": 13,
+          "ocorrencias": 9
+        },
+        "razaoTituloWorkhorse": 11.08,
+        "titulosDetalhes": [
+          {
+            "px": 144,
+            "elementos": 1,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "AUGUSTO\nMENCHACA"
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "129.6px",
+            "lineHeightRazao": 0.9,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-5.76px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 9,
+            "maiorLarguraCh": 9,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 72,
+            "elementos": 7,
+            "caracteres": 437,
+            "palavras": 62,
+            "textos": [
+              "Transformando pesquisa hidrológica nacional em uma ferramenta digital utilizável.",
+              "Levando um projeto de cliente dos requisitos à produção.",
+              "Conectando necessidades do cliente, decisões de design e desenvolvimento.",
+              "Testando quando machine learning quântico realmente faz diferença.",
+              "De software científico à pesquisa em IA aplicada.",
+              "O que quero entender a seguir."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "75.6px",
+            "lineHeightRazao": 1.05,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-1.44px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 24,
+            "maiorLarguraCh": 24,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 10,
+            "elementos": 2,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "Navegação",
+              "Contato"
+            ],
+            "fontFamily": "\"IBM Plex Mono\", monospace",
+            "familiaEfetiva": "IBM Plex Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ibm plex mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "14.4px",
+            "lineHeightRazao": 1.44,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "0.192px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 47,
+            "maiorLarguraCh": 47,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 13,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "19.68px",
+          "lineHeightRazao": 1.51,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 34
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            144,
+            72,
+            11,
+            10
+          ],
+          "workhorse_semFiltro": {
+            "px": 14,
+            "ocorrencias": 16
+          },
+          "razao_semFiltro": 10.29,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS REAIS\nBreast Cancer Wisconsin"
+            },
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS SINTÉTICOS\nQiskit ad_hoc_data"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 23,
+          "caracteresTotais": 467,
+          "caracteresPor1000px": 45.92,
+          "semNeutralizar": 13,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 12
+          },
+          {
+            "familia": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 8
+          },
+          {
+            "familia": "\"IBM Plex Mono\", monospace",
+            "contagem": 7
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 232,
+          "tag": "div",
+          "className": "footer-wordmark",
+          "caracteres": 7,
+          "palavras": 1,
+          "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Instrument Sans",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 96.6
+        },
+        "pontoCego": true,
+        "diferencaPx": 88,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            144,
+            72,
+            10
+          ],
+          "maiorTexto": 232
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            144,
+            72,
+            10
+          ],
+          "maiorTexto": 232
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            144,
+            72,
+            10
+          ],
+          "maiorTexto": 232
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            144,
+            72,
+            10
+          ],
+          "maiorTexto": 232
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            144,
+            72,
+            10
+          ],
+          "maiorTexto": 232
+        }
+      ],
+      "variante": "C-escala-evento-curto",
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
     }
   }
 }

--- a/docs/design/tipografia/medicoes.json
+++ b/docs/design/tipografia/medicoes.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "gerado": "2026-09-11T01:01:44.682Z",
+    "gerado": "2026-09-11T03:03:40.453Z",
     "comando": "node docs/design/tipografia/medir.mjs --headed",
     "comandoOficial": "node docs/design/tipografia/medir.mjs --headed",
     "modo": "headed",
@@ -16,12 +16,12 @@
   "referencias": {
     "aelixa": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:01:58.279Z",
+      "dataHora": "2026-09-11T03:03:55.244Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 17502,
         "imgs": 81,
-        "carregadas": 57
+        "carregadas": 58
       },
       "data": {
         "url": "https://aelixa.webflow.io/",
@@ -520,7 +520,7 @@
     },
     "illoca": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:02:09.897Z",
+      "dataHora": "2026-09-11T03:04:08.193Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 900,
@@ -917,12 +917,12 @@
     },
     "paulkalkbrenner": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:02:29.794Z",
+      "dataHora": "2026-09-11T03:04:31.484Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 10709,
         "imgs": 83,
-        "carregadas": 67
+        "carregadas": 66
       },
       "data": {
         "url": "https://www.paulkalkbrenner.net/",
@@ -1190,7 +1190,32 @@
         },
         "descartes": {
           "titulos": [],
-          "porRecorte": []
+          "porRecorte": [
+            {
+              "px": 641,
+              "tag": "span",
+              "fracaoContida": 0.05,
+              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+            },
+            {
+              "px": 641,
+              "tag": "span",
+              "fracaoContida": 0.05,
+              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+            },
+            {
+              "px": 641,
+              "tag": "span",
+              "fracaoContida": 0.05,
+              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+            },
+            {
+              "px": 641,
+              "tag": "span",
+              "fracaoContida": 0.05,
+              "texto": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n0\n1\n2\n3\n4\n5\n6\n7\n8\n9"
+            }
+          ]
         },
         "caixaAlta": {
           "elementos": 183,
@@ -1207,22 +1232,22 @@
           }
         ],
         "maiorTextoRenderizado": {
-          "px": 641,
+          "px": 150,
           "tag": "span",
-          "className": "",
-          "caracteres": 1,
+          "className": "h-d__span",
+          "caracteres": 4,
           "palavras": 1,
           "fontFamily": "\"ABC Diatype Plus Variable\", Arial, sans-serif",
           "familiaEfetiva": "ABC Diatype Plus Variable",
           "familiaVerificada": true,
           "serifa": false,
-          "fontWeight": "400",
+          "fontWeight": "700",
           "textTransform": "none",
           "fracaoContida": 1,
-          "profundidadeDeRolagem": 83.1
+          "profundidadeDeRolagem": 3.4
         },
-        "pontoCego": true,
-        "diferencaPx": 491,
+        "pontoCego": false,
+        "diferencaPx": 0,
         "_amostras": 5,
         "_instavel": false
       },
@@ -1275,7 +1300,7 @@
             18,
             11
           ],
-          "maiorTexto": 641
+          "maiorTexto": 150
         }
       ],
       "rotulo": "aprovado",
@@ -1283,7 +1308,7 @@
     },
     "lxlcreative": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:02:46.807Z",
+      "dataHora": "2026-09-11T03:04:53.979Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 15323,
@@ -1765,7 +1790,7 @@
     },
     "white-desert": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:03:01.949Z",
+      "dataHora": "2026-09-11T03:05:10.676Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 20787,
@@ -2271,7 +2296,7 @@
     },
     "charityshot": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:03:12.060Z",
+      "dataHora": "2026-09-11T03:05:20.922Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 900,
@@ -2490,7 +2515,7 @@
     },
     "obspogon": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:03:28.317Z",
+      "dataHora": "2026-09-11T03:05:37.486Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 3061,
@@ -2728,7 +2753,7 @@
     },
     "paulfragara": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:03:39.527Z",
+      "dataHora": "2026-09-11T03:05:48.049Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 1431,
@@ -3003,7 +3028,7 @@
     },
     "lowmess": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:03:50.681Z",
+      "dataHora": "2026-09-11T03:05:58.443Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 1234,
@@ -3277,12 +3302,12 @@
     },
     "simonbetton": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:04:03.794Z",
+      "dataHora": "2026-09-11T03:06:11.601Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 9298,
         "imgs": 14,
-        "carregadas": 6
+        "carregadas": 5
       },
       "data": {
         "url": "https://www.simonbetton.com/",
@@ -3623,7 +3648,7 @@
     },
     "nextfive": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:04:15.562Z",
+      "dataHora": "2026-09-11T03:06:24.045Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 2915,
@@ -3953,7 +3978,7 @@
     },
     "incomescrane": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:04:27.237Z",
+      "dataHora": "2026-09-11T03:06:35.982Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 4056,
@@ -4174,7 +4199,7 @@
     },
     "shelomoh": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:04:38.446Z",
+      "dataHora": "2026-09-11T03:06:47.609Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 2364,
@@ -4434,7 +4459,7 @@
     },
     "thatmlopsguy": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:04:49.188Z",
+      "dataHora": "2026-09-11T03:06:58.762Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 3602,
@@ -4803,7 +4828,7 @@
     },
     "cassidoo": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:05:00.123Z",
+      "dataHora": "2026-09-11T03:07:09.602Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 1654,
@@ -5063,7 +5088,7 @@
     },
     "ciere": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:05:11.358Z",
+      "dataHora": "2026-09-11T03:07:21.462Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 6297,
@@ -5491,7 +5516,7 @@
     },
     "idf-br": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:05:22.039Z",
+      "dataHora": "2026-09-11T03:07:32.584Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 929,
@@ -5777,7 +5802,7 @@
     },
     "dvo": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:05:32.747Z",
+      "dataHora": "2026-09-11T03:07:43.093Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 900,
@@ -6019,7 +6044,7 @@
   "variantesDaLP": {
     "A-lp-atual@320": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:05:44.717Z",
+      "dataHora": "2026-09-11T03:07:55.540Z",
       "viewport": "320x568x2",
       "rolagem": {
         "altura": 11644,
@@ -6354,16 +6379,16 @@
     },
     "B-so-escala@320": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:05:57.170Z",
+      "dataHora": "2026-09-11T03:08:08.405Z",
       "viewport": "320x568x2",
       "rolagem": {
-        "altura": 13484,
+        "altura": 13519,
         "imgs": 0,
         "carregadas": 0
       },
       "data": {
         "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
-        "altura": 13484,
+        "altura": 13519,
         "fontes": {
           "status": "loaded",
           "carregadas": 33
@@ -6373,7 +6398,7 @@
           "h": 568,
           "dpr": 2
         },
-        "telas": 23.7,
+        "telas": 23.8,
         "telas_base900_legado": 15,
         "metricaV2_hsvS015": 0.9,
         "corPerceptivel_C005": 0.9,
@@ -6390,7 +6415,7 @@
           },
           {
             "cor": "rgb(232,227,217)",
-            "pct": 16.7,
+            "pct": 16.6,
             "L": 0.92,
             "C": 0.014,
             "H": 85
@@ -6440,7 +6465,7 @@
         "keyframesPor1000": 0.22,
         "folhasBloqueadas": 1,
         "emTransicao": 75,
-        "emTransicaoPor1000": 5.56,
+        "emTransicaoPor1000": 5.55,
         "animacoesAtivas": 8,
         "duracoes": [
           [
@@ -6457,7 +6482,7 @@
           ]
         ],
         "tamTitulos": [
-          48,
+          49,
           36,
           10
         ],
@@ -6465,10 +6490,10 @@
           "px": 13,
           "ocorrencias": 9
         },
-        "razaoTituloWorkhorse": 3.69,
+        "razaoTituloWorkhorse": 3.77,
         "titulosDetalhes": [
           {
-            "px": 48,
+            "px": 49,
             "elementos": 1,
             "caracteres": 59,
             "palavras": 8,
@@ -6483,10 +6508,10 @@
             "serifa": false,
             "serifa_pelaDeclarada_legado": false,
             "fontWeight": "700",
-            "lineHeightPx": "43.2px",
-            "lineHeightRazao": 0.9,
+            "lineHeightPx": "49px",
+            "lineHeightRazao": 1,
             "lineHeightOrigem": "declarada",
-            "letterSpacing": "-1.92px",
+            "letterSpacing": "-1.96px",
             "textTransform": "none",
             "inFirstViewport": true,
             "largura_ch": 9,
@@ -6568,7 +6593,7 @@
         },
         "_legado": {
           "tamTitulos_semFiltro": [
-            48,
+            49,
             36,
             11,
             10
@@ -6577,7 +6602,7 @@
             "px": 13,
             "ocorrencias": 19
           },
-          "razao_semFiltro": 3.69,
+          "razao_semFiltro": 3.77,
           "divergeDoCorrigido": false
         },
         "descartes": {
@@ -6598,8 +6623,8 @@
         "caixaAlta": {
           "elementos": 23,
           "caracteresTotais": 467,
-          "caracteresPor1000px": 34.63,
-          "semNeutralizar": 13,
+          "caracteresPor1000px": 34.54,
+          "semNeutralizar": 11,
           "passeNeutralizado": true,
           "amostras": 6
         },
@@ -6633,7 +6658,7 @@
           "profundidadeDeRolagem": 98.5
         },
         "pontoCego": true,
-        "diferencaPx": 12,
+        "diferencaPx": 11,
         "_amostras": 5,
         "_instavel": false
       },
@@ -6641,7 +6666,7 @@
         {
           "quando": "t+4s",
           "tamTitulos": [
-            48,
+            49,
             36,
             10
           ],
@@ -6650,7 +6675,7 @@
         {
           "quando": "t+5.5s",
           "tamTitulos": [
-            48,
+            49,
             36,
             10
           ],
@@ -6659,7 +6684,7 @@
         {
           "quando": "t+7s",
           "tamTitulos": [
-            48,
+            49,
             36,
             10
           ],
@@ -6668,7 +6693,7 @@
         {
           "quando": "t+8.5s",
           "tamTitulos": [
-            48,
+            49,
             36,
             10
           ],
@@ -6677,7 +6702,7 @@
         {
           "quando": "pos-rolagem",
           "tamTitulos": [
-            48,
+            49,
             36,
             10
           ],
@@ -6689,16 +6714,16 @@
     },
     "C-escala-evento-curto@320": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:06:09.719Z",
+      "dataHora": "2026-09-11T03:08:21.318Z",
       "viewport": "320x568x2",
       "rolagem": {
-        "altura": 13395,
+        "altura": 13407,
         "imgs": 0,
         "carregadas": 0
       },
       "data": {
         "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
-        "altura": 13395,
+        "altura": 13407,
         "fontes": {
           "status": "loaded",
           "carregadas": 33
@@ -6718,7 +6743,7 @@
         "fundos": [
           {
             "cor": "rgb(247,245,239)",
-            "pct": 65.6,
+            "pct": 65.7,
             "L": 0.97,
             "C": 0.008,
             "H": 91
@@ -6775,7 +6800,7 @@
         "keyframesPor1000": 0.22,
         "folhasBloqueadas": 1,
         "emTransicao": 75,
-        "emTransicaoPor1000": 5.6,
+        "emTransicaoPor1000": 5.59,
         "animacoesAtivas": 8,
         "duracoes": [
           [
@@ -6792,7 +6817,7 @@
           ]
         ],
         "tamTitulos": [
-          48,
+          49,
           36,
           10
         ],
@@ -6800,10 +6825,10 @@
           "px": 13,
           "ocorrencias": 9
         },
-        "razaoTituloWorkhorse": 3.69,
+        "razaoTituloWorkhorse": 3.77,
         "titulosDetalhes": [
           {
-            "px": 48,
+            "px": 49,
             "elementos": 1,
             "caracteres": 16,
             "palavras": 2,
@@ -6818,10 +6843,10 @@
             "serifa": false,
             "serifa_pelaDeclarada_legado": false,
             "fontWeight": "700",
-            "lineHeightPx": "43.2px",
-            "lineHeightRazao": 0.9,
+            "lineHeightPx": "49px",
+            "lineHeightRazao": 1,
             "lineHeightOrigem": "declarada",
-            "letterSpacing": "-1.92px",
+            "letterSpacing": "-1.96px",
             "textTransform": "none",
             "inFirstViewport": true,
             "largura_ch": 9,
@@ -6903,7 +6928,7 @@
         },
         "_legado": {
           "tamTitulos_semFiltro": [
-            48,
+            49,
             36,
             11,
             10
@@ -6912,7 +6937,7 @@
             "px": 13,
             "ocorrencias": 19
           },
-          "razao_semFiltro": 3.69,
+          "razao_semFiltro": 3.77,
           "divergeDoCorrigido": false
         },
         "descartes": {
@@ -6933,8 +6958,8 @@
         "caixaAlta": {
           "elementos": 23,
           "caracteresTotais": 467,
-          "caracteresPor1000px": 34.86,
-          "semNeutralizar": 13,
+          "caracteresPor1000px": 34.83,
+          "semNeutralizar": 11,
           "passeNeutralizado": true,
           "amostras": 6
         },
@@ -6968,7 +6993,7 @@
           "profundidadeDeRolagem": 98.5
         },
         "pontoCego": true,
-        "diferencaPx": 12,
+        "diferencaPx": 11,
         "_amostras": 5,
         "_instavel": false
       },
@@ -6976,7 +7001,7 @@
         {
           "quando": "t+4s",
           "tamTitulos": [
-            48,
+            49,
             36,
             10
           ],
@@ -6985,7 +7010,7 @@
         {
           "quando": "t+5.5s",
           "tamTitulos": [
-            48,
+            49,
             36,
             10
           ],
@@ -6994,7 +7019,7 @@
         {
           "quando": "t+7s",
           "tamTitulos": [
-            48,
+            49,
             36,
             10
           ],
@@ -7003,7 +7028,7 @@
         {
           "quando": "t+8.5s",
           "tamTitulos": [
-            48,
+            49,
             36,
             10
           ],
@@ -7012,7 +7037,7 @@
         {
           "quando": "pos-rolagem",
           "tamTitulos": [
-            48,
+            49,
             36,
             10
           ],
@@ -7024,7 +7049,7 @@
     },
     "A-lp-atual@390": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:06:21.187Z",
+      "dataHora": "2026-09-11T03:08:33.186Z",
       "viewport": "390x844x2",
       "rolagem": {
         "altura": 11078,
@@ -7359,16 +7384,351 @@
     },
     "B-so-escala@390": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:06:33.444Z",
+      "dataHora": "2026-09-11T03:08:45.792Z",
       "viewport": "390x844x2",
       "rolagem": {
-        "altura": 12444,
+        "altura": 12499,
         "imgs": 0,
         "carregadas": 0
       },
       "data": {
         "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
-        "altura": 12444,
+        "altura": 12499,
+        "fontes": {
+          "status": "loaded",
+          "carregadas": 33
+        },
+        "viewportMedido": {
+          "w": 390,
+          "h": 844,
+          "dpr": 2
+        },
+        "telas": 14.8,
+        "telas_base900_legado": 13.9,
+        "metricaV2_hsvS015": 0.9,
+        "corPerceptivel_C005": 0.9,
+        "corForte_C012": 0.8,
+        "cromaMedioPonderado": 0.01,
+        "cromaPicoOklch": 0.201,
+        "fundos": [
+          {
+            "cor": "rgb(247,245,239)",
+            "pct": 65.4,
+            "L": 0.97,
+            "C": 0.008,
+            "H": 91
+          },
+          {
+            "cor": "rgb(232,227,217)",
+            "pct": 16.1,
+            "L": 0.92,
+            "C": 0.014,
+            "H": 85
+          },
+          {
+            "cor": "rgb(17,18,19)",
+            "pct": 8.4,
+            "L": 0.18,
+            "C": 0.003,
+            "H": 248
+          },
+          {
+            "cor": "rgb(11,11,11)",
+            "pct": 5.4,
+            "L": 0.15,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(255,255,255)",
+            "pct": 2.6,
+            "L": 1,
+            "C": 0,
+            "H": 90
+          },
+          {
+            "cor": "rgb(241,238,230)",
+            "pct": 1,
+            "L": 0.95,
+            "C": 0.011,
+            "H": 90
+          }
+        ],
+        "midia": {
+          "img": 0,
+          "svg": 2,
+          "video": 0,
+          "canvas": 0
+        },
+        "midiaTotalPor1000": 0.16,
+        "keyframes": 3,
+        "nomes": [
+          "rail-scroll",
+          "heroUp",
+          "heroLine"
+        ],
+        "keyframesPor1000": 0.24,
+        "folhasBloqueadas": 1,
+        "emTransicao": 75,
+        "emTransicaoPor1000": 6,
+        "animacoesAtivas": 8,
+        "duracoes": [
+          [
+            "0.6s",
+            50
+          ],
+          [
+            "0.2s",
+            30
+          ],
+          [
+            "0.18s",
+            23
+          ]
+        ],
+        "tamTitulos": [
+          54,
+          36,
+          10
+        ],
+        "workhorse": {
+          "px": 13,
+          "ocorrencias": 9
+        },
+        "razaoTituloWorkhorse": 4.15,
+        "titulosDetalhes": [
+          {
+            "px": 54,
+            "elementos": 1,
+            "caracteres": 59,
+            "palavras": 8,
+            "textos": [
+              "Construo produtos digitais e lidero projetos de tecnologia."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "700",
+            "lineHeightPx": "54px",
+            "lineHeightRazao": 1,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-2.16px",
+            "textTransform": "none",
+            "inFirstViewport": true,
+            "largura_ch": 10,
+            "maiorLarguraCh": 10,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 36,
+            "elementos": 7,
+            "caracteres": 437,
+            "palavras": 62,
+            "textos": [
+              "Transformando pesquisa hidrológica nacional em uma ferramenta digital utilizável.",
+              "Levando um projeto de cliente dos requisitos à produção.",
+              "Conectando necessidades do cliente, decisões de design e desenvolvimento.",
+              "Testando quando machine learning quântico realmente faz diferença.",
+              "De software científico à pesquisa em IA aplicada.",
+              "O que quero entender a seguir."
+            ],
+            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "familiaEfetiva": "Instrument Sans",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "instrument sans",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "37.8px",
+            "lineHeightRazao": 1.05,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "-0.72px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 15,
+            "maiorLarguraCh": 15,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          },
+          {
+            "px": 10,
+            "elementos": 2,
+            "caracteres": 16,
+            "palavras": 2,
+            "textos": [
+              "Navegação",
+              "Contato"
+            ],
+            "fontFamily": "\"IBM Plex Mono\", monospace",
+            "familiaEfetiva": "IBM Plex Mono",
+            "familiaVerificada": true,
+            "caiuParaFallback": false,
+            "familiaDeclarada": "ibm plex mono",
+            "serifa": false,
+            "serifa_pelaDeclarada_legado": false,
+            "fontWeight": "600",
+            "lineHeightPx": "14.4px",
+            "lineHeightRazao": 1.44,
+            "lineHeightOrigem": "declarada",
+            "letterSpacing": "0.192px",
+            "textTransform": "none",
+            "inFirstViewport": false,
+            "largura_ch": 28,
+            "maiorLarguraCh": 28,
+            "fracaoContidaMin": 1,
+            "vistoEmAmostras": "5/5"
+          }
+        ],
+        "workhorseDetalhe": {
+          "px": 13,
+          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Inter",
+          "familiaVerificada": true,
+          "serifa": false,
+          "lineHeightPx": "19.68px",
+          "lineHeightRazao": 1.51,
+          "lineHeightOrigem": "declarada",
+          "largura_ch": 34
+        },
+        "_legado": {
+          "tamTitulos_semFiltro": [
+            54,
+            36,
+            11,
+            10
+          ],
+          "workhorse_semFiltro": {
+            "px": 13,
+            "ocorrencias": 19
+          },
+          "razao_semFiltro": 4.15,
+          "divergeDoCorrigido": false
+        },
+        "descartes": {
+          "titulos": [
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS REAIS\nBreast Cancer Wisconsin"
+            },
+            {
+              "px": 11,
+              "motivo": "opacidade-0",
+              "texto": "DADOS SINTÉTICOS\nQiskit ad_hoc_data"
+            }
+          ],
+          "porRecorte": []
+        },
+        "caixaAlta": {
+          "elementos": 23,
+          "caracteresTotais": 467,
+          "caracteresPor1000px": 37.36,
+          "semNeutralizar": 13,
+          "passeNeutralizado": true,
+          "amostras": 6
+        },
+        "familiasUsadas": [
+          {
+            "familia": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 11
+          },
+          {
+            "familia": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 8
+          },
+          {
+            "familia": "\"IBM Plex Mono\", monospace",
+            "contagem": 7
+          }
+        ],
+        "maiorTextoRenderizado": {
+          "px": 73,
+          "tag": "div",
+          "className": "footer-wordmark",
+          "caracteres": 7,
+          "palavras": 1,
+          "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
+          "familiaEfetiva": "Instrument Sans",
+          "familiaVerificada": true,
+          "serifa": false,
+          "fontWeight": "700",
+          "textTransform": "none",
+          "fracaoContida": 1,
+          "profundidadeDeRolagem": 98.3
+        },
+        "pontoCego": true,
+        "diferencaPx": 19,
+        "_amostras": 5,
+        "_instavel": false
+      },
+      "amostras": [
+        {
+          "quando": "t+4s",
+          "tamTitulos": [
+            54,
+            36,
+            10
+          ],
+          "maiorTexto": 73
+        },
+        {
+          "quando": "t+5.5s",
+          "tamTitulos": [
+            54,
+            36,
+            10
+          ],
+          "maiorTexto": 73
+        },
+        {
+          "quando": "t+7s",
+          "tamTitulos": [
+            54,
+            36,
+            10
+          ],
+          "maiorTexto": 73
+        },
+        {
+          "quando": "t+8.5s",
+          "tamTitulos": [
+            54,
+            36,
+            10
+          ],
+          "maiorTexto": 73
+        },
+        {
+          "quando": "pos-rolagem",
+          "tamTitulos": [
+            54,
+            36,
+            10
+          ],
+          "maiorTexto": 73
+        }
+      ],
+      "variante": "B-so-escala",
+      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
+    },
+    "C-escala-evento-curto@390": {
+      "status": "sucesso",
+      "dataHora": "2026-09-11T03:08:58.541Z",
+      "viewport": "390x844x2",
+      "rolagem": {
+        "altura": 12421,
+        "imgs": 0,
+        "carregadas": 0
+      },
+      "data": {
+        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
+        "altura": 12421,
         "fontes": {
           "status": "loaded",
           "carregadas": 33
@@ -7445,7 +7805,7 @@
         "keyframesPor1000": 0.24,
         "folhasBloqueadas": 1,
         "emTransicao": 75,
-        "emTransicaoPor1000": 6.03,
+        "emTransicaoPor1000": 6.04,
         "animacoesAtivas": 8,
         "duracoes": [
           [
@@ -7462,7 +7822,7 @@
           ]
         ],
         "tamTitulos": [
-          48,
+          54,
           36,
           10
         ],
@@ -7470,345 +7830,10 @@
           "px": 13,
           "ocorrencias": 9
         },
-        "razaoTituloWorkhorse": 3.69,
+        "razaoTituloWorkhorse": 4.15,
         "titulosDetalhes": [
           {
-            "px": 48,
-            "elementos": 1,
-            "caracteres": 59,
-            "palavras": 8,
-            "textos": [
-              "Construo produtos digitais e lidero projetos de tecnologia."
-            ],
-            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
-            "familiaEfetiva": "Instrument Sans",
-            "familiaVerificada": true,
-            "caiuParaFallback": false,
-            "familiaDeclarada": "instrument sans",
-            "serifa": false,
-            "serifa_pelaDeclarada_legado": false,
-            "fontWeight": "700",
-            "lineHeightPx": "43.2px",
-            "lineHeightRazao": 0.9,
-            "lineHeightOrigem": "declarada",
-            "letterSpacing": "-1.92px",
-            "textTransform": "none",
-            "inFirstViewport": true,
-            "largura_ch": 11,
-            "maiorLarguraCh": 11,
-            "fracaoContidaMin": 1,
-            "vistoEmAmostras": "5/5"
-          },
-          {
-            "px": 36,
-            "elementos": 7,
-            "caracteres": 437,
-            "palavras": 62,
-            "textos": [
-              "Transformando pesquisa hidrológica nacional em uma ferramenta digital utilizável.",
-              "Levando um projeto de cliente dos requisitos à produção.",
-              "Conectando necessidades do cliente, decisões de design e desenvolvimento.",
-              "Testando quando machine learning quântico realmente faz diferença.",
-              "De software científico à pesquisa em IA aplicada.",
-              "O que quero entender a seguir."
-            ],
-            "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
-            "familiaEfetiva": "Instrument Sans",
-            "familiaVerificada": true,
-            "caiuParaFallback": false,
-            "familiaDeclarada": "instrument sans",
-            "serifa": false,
-            "serifa_pelaDeclarada_legado": false,
-            "fontWeight": "600",
-            "lineHeightPx": "37.8px",
-            "lineHeightRazao": 1.05,
-            "lineHeightOrigem": "declarada",
-            "letterSpacing": "-0.72px",
-            "textTransform": "none",
-            "inFirstViewport": false,
-            "largura_ch": 15,
-            "maiorLarguraCh": 15,
-            "fracaoContidaMin": 1,
-            "vistoEmAmostras": "5/5"
-          },
-          {
-            "px": 10,
-            "elementos": 2,
-            "caracteres": 16,
-            "palavras": 2,
-            "textos": [
-              "Navegação",
-              "Contato"
-            ],
-            "fontFamily": "\"IBM Plex Mono\", monospace",
-            "familiaEfetiva": "IBM Plex Mono",
-            "familiaVerificada": true,
-            "caiuParaFallback": false,
-            "familiaDeclarada": "ibm plex mono",
-            "serifa": false,
-            "serifa_pelaDeclarada_legado": false,
-            "fontWeight": "600",
-            "lineHeightPx": "14.4px",
-            "lineHeightRazao": 1.44,
-            "lineHeightOrigem": "declarada",
-            "letterSpacing": "0.192px",
-            "textTransform": "none",
-            "inFirstViewport": false,
-            "largura_ch": 28,
-            "maiorLarguraCh": 28,
-            "fracaoContidaMin": 1,
-            "vistoEmAmostras": "5/5"
-          }
-        ],
-        "workhorseDetalhe": {
-          "px": 13,
-          "fontFamily": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
-          "familiaEfetiva": "Inter",
-          "familiaVerificada": true,
-          "serifa": false,
-          "lineHeightPx": "19.68px",
-          "lineHeightRazao": 1.51,
-          "lineHeightOrigem": "declarada",
-          "largura_ch": 34
-        },
-        "_legado": {
-          "tamTitulos_semFiltro": [
-            48,
-            36,
-            11,
-            10
-          ],
-          "workhorse_semFiltro": {
-            "px": 13,
-            "ocorrencias": 19
-          },
-          "razao_semFiltro": 3.69,
-          "divergeDoCorrigido": false
-        },
-        "descartes": {
-          "titulos": [
-            {
-              "px": 11,
-              "motivo": "opacidade-0",
-              "texto": "DADOS REAIS\nBreast Cancer Wisconsin"
-            },
-            {
-              "px": 11,
-              "motivo": "opacidade-0",
-              "texto": "DADOS SINTÉTICOS\nQiskit ad_hoc_data"
-            }
-          ],
-          "porRecorte": []
-        },
-        "caixaAlta": {
-          "elementos": 23,
-          "caracteresTotais": 467,
-          "caracteresPor1000px": 37.53,
-          "semNeutralizar": 13,
-          "passeNeutralizado": true,
-          "amostras": 6
-        },
-        "familiasUsadas": [
-          {
-            "familia": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
-            "contagem": 11
-          },
-          {
-            "familia": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
-            "contagem": 8
-          },
-          {
-            "familia": "\"IBM Plex Mono\", monospace",
-            "contagem": 7
-          }
-        ],
-        "maiorTextoRenderizado": {
-          "px": 73,
-          "tag": "div",
-          "className": "footer-wordmark",
-          "caracteres": 7,
-          "palavras": 1,
-          "fontFamily": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
-          "familiaEfetiva": "Instrument Sans",
-          "familiaVerificada": true,
-          "serifa": false,
-          "fontWeight": "700",
-          "textTransform": "none",
-          "fracaoContida": 1,
-          "profundidadeDeRolagem": 98.3
-        },
-        "pontoCego": true,
-        "diferencaPx": 25,
-        "_amostras": 5,
-        "_instavel": false
-      },
-      "amostras": [
-        {
-          "quando": "t+4s",
-          "tamTitulos": [
-            48,
-            36,
-            10
-          ],
-          "maiorTexto": 73
-        },
-        {
-          "quando": "t+5.5s",
-          "tamTitulos": [
-            48,
-            36,
-            10
-          ],
-          "maiorTexto": 73
-        },
-        {
-          "quando": "t+7s",
-          "tamTitulos": [
-            48,
-            36,
-            10
-          ],
-          "maiorTexto": 73
-        },
-        {
-          "quando": "t+8.5s",
-          "tamTitulos": [
-            48,
-            36,
-            10
-          ],
-          "maiorTexto": 73
-        },
-        {
-          "quando": "pos-rolagem",
-          "tamTitulos": [
-            48,
-            36,
-            10
-          ],
-          "maiorTexto": 73
-        }
-      ],
-      "variante": "B-so-escala",
-      "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html"
-    },
-    "C-escala-evento-curto@390": {
-      "status": "sucesso",
-      "dataHora": "2026-09-11T01:06:45.749Z",
-      "viewport": "390x844x2",
-      "rolagem": {
-        "altura": 12399,
-        "imgs": 0,
-        "carregadas": 0
-      },
-      "data": {
-        "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
-        "altura": 12399,
-        "fontes": {
-          "status": "loaded",
-          "carregadas": 33
-        },
-        "viewportMedido": {
-          "w": 390,
-          "h": 844,
-          "dpr": 2
-        },
-        "telas": 14.7,
-        "telas_base900_legado": 13.8,
-        "metricaV2_hsvS015": 0.9,
-        "corPerceptivel_C005": 0.9,
-        "corForte_C012": 0.8,
-        "cromaMedioPonderado": 0.01,
-        "cromaPicoOklch": 0.201,
-        "fundos": [
-          {
-            "cor": "rgb(247,245,239)",
-            "pct": 65.2,
-            "L": 0.97,
-            "C": 0.008,
-            "H": 91
-          },
-          {
-            "cor": "rgb(232,227,217)",
-            "pct": 16.2,
-            "L": 0.92,
-            "C": 0.014,
-            "H": 85
-          },
-          {
-            "cor": "rgb(17,18,19)",
-            "pct": 8.4,
-            "L": 0.18,
-            "C": 0.003,
-            "H": 248
-          },
-          {
-            "cor": "rgb(11,11,11)",
-            "pct": 5.4,
-            "L": 0.15,
-            "C": 0,
-            "H": 90
-          },
-          {
-            "cor": "rgb(255,255,255)",
-            "pct": 2.6,
-            "L": 1,
-            "C": 0,
-            "H": 90
-          },
-          {
-            "cor": "rgb(241,238,230)",
-            "pct": 1,
-            "L": 0.95,
-            "C": 0.011,
-            "H": 90
-          }
-        ],
-        "midia": {
-          "img": 0,
-          "svg": 2,
-          "video": 0,
-          "canvas": 0
-        },
-        "midiaTotalPor1000": 0.16,
-        "keyframes": 3,
-        "nomes": [
-          "rail-scroll",
-          "heroUp",
-          "heroLine"
-        ],
-        "keyframesPor1000": 0.24,
-        "folhasBloqueadas": 1,
-        "emTransicao": 75,
-        "emTransicaoPor1000": 6.05,
-        "animacoesAtivas": 8,
-        "duracoes": [
-          [
-            "0.6s",
-            50
-          ],
-          [
-            "0.2s",
-            30
-          ],
-          [
-            "0.18s",
-            23
-          ]
-        ],
-        "tamTitulos": [
-          48,
-          36,
-          10
-        ],
-        "workhorse": {
-          "px": 13,
-          "ocorrencias": 9
-        },
-        "razaoTituloWorkhorse": 3.69,
-        "titulosDetalhes": [
-          {
-            "px": 48,
+            "px": 54,
             "elementos": 1,
             "caracteres": 16,
             "palavras": 2,
@@ -7823,14 +7848,14 @@
             "serifa": false,
             "serifa_pelaDeclarada_legado": false,
             "fontWeight": "700",
-            "lineHeightPx": "43.2px",
-            "lineHeightRazao": 0.9,
+            "lineHeightPx": "54px",
+            "lineHeightRazao": 1,
             "lineHeightOrigem": "declarada",
-            "letterSpacing": "-1.92px",
+            "letterSpacing": "-2.16px",
             "textTransform": "none",
             "inFirstViewport": true,
-            "largura_ch": 11,
-            "maiorLarguraCh": 11,
+            "largura_ch": 10,
+            "maiorLarguraCh": 10,
             "fracaoContidaMin": 1,
             "vistoEmAmostras": "5/5"
           },
@@ -7908,7 +7933,7 @@
         },
         "_legado": {
           "tamTitulos_semFiltro": [
-            48,
+            54,
             36,
             11,
             10
@@ -7917,7 +7942,7 @@
             "px": 13,
             "ocorrencias": 19
           },
-          "razao_semFiltro": 3.69,
+          "razao_semFiltro": 4.15,
           "divergeDoCorrigido": false
         },
         "descartes": {
@@ -7938,7 +7963,7 @@
         "caixaAlta": {
           "elementos": 23,
           "caracteresTotais": 467,
-          "caracteresPor1000px": 37.66,
+          "caracteresPor1000px": 37.6,
           "semNeutralizar": 13,
           "passeNeutralizado": true,
           "amostras": 6
@@ -7973,7 +7998,7 @@
           "profundidadeDeRolagem": 98.3
         },
         "pontoCego": true,
-        "diferencaPx": 25,
+        "diferencaPx": 19,
         "_amostras": 5,
         "_instavel": false
       },
@@ -7981,7 +8006,7 @@
         {
           "quando": "t+4s",
           "tamTitulos": [
-            48,
+            54,
             36,
             10
           ],
@@ -7990,7 +8015,7 @@
         {
           "quando": "t+5.5s",
           "tamTitulos": [
-            48,
+            54,
             36,
             10
           ],
@@ -7999,7 +8024,7 @@
         {
           "quando": "t+7s",
           "tamTitulos": [
-            48,
+            54,
             36,
             10
           ],
@@ -8008,7 +8033,7 @@
         {
           "quando": "t+8.5s",
           "tamTitulos": [
-            48,
+            54,
             36,
             10
           ],
@@ -8017,7 +8042,7 @@
         {
           "quando": "pos-rolagem",
           "tamTitulos": [
-            48,
+            54,
             36,
             10
           ],
@@ -8029,7 +8054,7 @@
     },
     "A-lp-atual@768": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:06:57.224Z",
+      "dataHora": "2026-09-11T03:09:10.417Z",
       "viewport": "768x1024x2",
       "rolagem": {
         "altura": 10934,
@@ -8364,7 +8389,7 @@
     },
     "B-so-escala@768": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:07:09.430Z",
+      "dataHora": "2026-09-11T03:09:22.955Z",
       "viewport": "768x1024x2",
       "rolagem": {
         "altura": 11586,
@@ -8699,7 +8724,7 @@
     },
     "C-escala-evento-curto@768": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:07:21.654Z",
+      "dataHora": "2026-09-11T03:09:35.603Z",
       "viewport": "768x1024x2",
       "rolagem": {
         "altura": 11532,
@@ -9034,7 +9059,7 @@
     },
     "A-lp-atual@1024": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:07:32.799Z",
+      "dataHora": "2026-09-11T03:09:47.114Z",
       "viewport": "1024x768x1",
       "rolagem": {
         "altura": 7762,
@@ -9279,18 +9304,18 @@
           "elementos": 96,
           "caracteresTotais": 1513,
           "caracteresPor1000px": 194.92,
-          "semNeutralizar": 61,
+          "semNeutralizar": 55,
           "passeNeutralizado": true,
           "amostras": 6
         },
         "familiasUsadas": [
           {
-            "familia": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
-            "contagem": 16
-          },
-          {
             "familia": "\"IBM Plex Mono\", monospace",
             "contagem": 15
+          },
+          {
+            "familia": "Inter, -apple-system, BlinkMacSystemFont, sans-serif",
+            "contagem": 12
           },
           {
             "familia": "\"Instrument Sans\", -apple-system, BlinkMacSystemFont, sans-serif",
@@ -9369,7 +9394,7 @@
     },
     "B-so-escala@1024": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:07:44.571Z",
+      "dataHora": "2026-09-11T03:09:59.367Z",
       "viewport": "1024x768x1",
       "rolagem": {
         "altura": 8826,
@@ -9704,16 +9729,16 @@
     },
     "C-escala-evento-curto@1024": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:07:56.345Z",
+      "dataHora": "2026-09-11T03:10:11.558Z",
       "viewport": "1024x768x1",
       "rolagem": {
-        "altura": 8541,
+        "altura": 8633,
         "imgs": 0,
         "carregadas": 0
       },
       "data": {
         "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
-        "altura": 8541,
+        "altura": 8633,
         "fontes": {
           "status": "loaded",
           "carregadas": 33
@@ -9723,24 +9748,24 @@
           "h": 768,
           "dpr": 1
         },
-        "telas": 11.1,
-        "telas_base900_legado": 9.5,
-        "metricaV2_hsvS015": 0.7,
-        "corPerceptivel_C005": 0.7,
+        "telas": 11.2,
+        "telas_base900_legado": 9.6,
+        "metricaV2_hsvS015": 0.6,
+        "corPerceptivel_C005": 0.6,
         "corForte_C012": 0.6,
         "cromaMedioPonderado": 0.009,
         "cromaPicoOklch": 0.201,
         "fundos": [
           {
             "cor": "rgb(247,245,239)",
-            "pct": 66.4,
+            "pct": 66.6,
             "L": 0.97,
             "C": 0.008,
             "H": 91
           },
           {
             "cor": "rgb(232,227,217)",
-            "pct": 16.9,
+            "pct": 16.8,
             "L": 0.92,
             "C": 0.014,
             "H": 85
@@ -9754,7 +9779,7 @@
           },
           {
             "cor": "rgb(11,11,11)",
-            "pct": 5.4,
+            "pct": 5.3,
             "L": 0.15,
             "C": 0,
             "H": 90
@@ -9790,7 +9815,7 @@
         "keyframesPor1000": 0.35,
         "folhasBloqueadas": 1,
         "emTransicao": 75,
-        "emTransicaoPor1000": 8.78,
+        "emTransicaoPor1000": 8.69,
         "animacoesAtivas": 9,
         "duracoes": [
           [
@@ -9948,7 +9973,7 @@
         "caixaAlta": {
           "elementos": 23,
           "caracteresTotais": 467,
-          "caracteresPor1000px": 54.68,
+          "caracteresPor1000px": 54.09,
           "semNeutralizar": 13,
           "passeNeutralizado": true,
           "amostras": 6
@@ -9980,7 +10005,7 @@
           "fontWeight": "700",
           "textTransform": "none",
           "fracaoContida": 1,
-          "profundidadeDeRolagem": 96.4
+          "profundidadeDeRolagem": 96.5
         },
         "pontoCego": true,
         "diferencaPx": 88,
@@ -10039,7 +10064,7 @@
     },
     "A-lp-atual@1440": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:08:07.351Z",
+      "dataHora": "2026-09-11T03:10:23.121Z",
       "viewport": "1440x900x1",
       "rolagem": {
         "altura": 8350,
@@ -10374,16 +10399,16 @@
     },
     "B-so-escala@1440": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:08:19.399Z",
+      "dataHora": "2026-09-11T03:10:35.618Z",
       "viewport": "1440x900x1",
       "rolagem": {
-        "altura": 10604,
+        "altura": 10863,
         "imgs": 0,
         "carregadas": 0
       },
       "data": {
         "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
-        "altura": 10604,
+        "altura": 10863,
         "fontes": {
           "status": "loaded",
           "carregadas": 33
@@ -10393,8 +10418,8 @@
           "h": 900,
           "dpr": 1
         },
-        "telas": 11.8,
-        "telas_base900_legado": 11.8,
+        "telas": 12.1,
+        "telas_base900_legado": 12.1,
         "metricaV2_hsvS015": 0.4,
         "corPerceptivel_C005": 0.4,
         "corForte_C012": 0.4,
@@ -10403,28 +10428,28 @@
         "fundos": [
           {
             "cor": "rgb(247,245,239)",
-            "pct": 68.1,
+            "pct": 68.6,
             "L": 0.97,
             "C": 0.008,
             "H": 91
           },
           {
             "cor": "rgb(232,227,217)",
-            "pct": 17.3,
+            "pct": 17,
             "L": 0.92,
             "C": 0.014,
             "H": 85
           },
           {
             "cor": "rgb(17,18,19)",
-            "pct": 6.8,
+            "pct": 6.7,
             "L": 0.18,
             "C": 0.003,
             "H": 248
           },
           {
             "cor": "rgb(11,11,11)",
-            "pct": 5.4,
+            "pct": 5.3,
             "L": 0.15,
             "C": 0,
             "H": 90
@@ -10450,7 +10475,7 @@
           "video": 0,
           "canvas": 0
         },
-        "midiaTotalPor1000": 0.19,
+        "midiaTotalPor1000": 0.18,
         "keyframes": 3,
         "nomes": [
           "rail-scroll",
@@ -10460,7 +10485,7 @@
         "keyframesPor1000": 0.28,
         "folhasBloqueadas": 1,
         "emTransicao": 75,
-        "emTransicaoPor1000": 7.07,
+        "emTransicaoPor1000": 6.9,
         "animacoesAtivas": 9,
         "duracoes": [
           [
@@ -10509,8 +10534,8 @@
             "letterSpacing": "-5.76px",
             "textTransform": "none",
             "inFirstViewport": true,
-            "largura_ch": 8,
-            "maiorLarguraCh": 8,
+            "largura_ch": 7,
+            "maiorLarguraCh": 7,
             "fracaoContidaMin": 1,
             "vistoEmAmostras": "5/5"
           },
@@ -10618,8 +10643,8 @@
         "caixaAlta": {
           "elementos": 23,
           "caracteresTotais": 467,
-          "caracteresPor1000px": 44.04,
-          "semNeutralizar": 13,
+          "caracteresPor1000px": 42.99,
+          "semNeutralizar": 11,
           "passeNeutralizado": true,
           "amostras": 6
         },
@@ -10650,7 +10675,7 @@
           "fontWeight": "700",
           "textTransform": "none",
           "fracaoContida": 1,
-          "profundidadeDeRolagem": 96.7
+          "profundidadeDeRolagem": 96.8
         },
         "pontoCego": true,
         "diferencaPx": 88,
@@ -10709,16 +10734,16 @@
     },
     "C-escala-evento-curto@1440": {
       "status": "sucesso",
-      "dataHora": "2026-09-11T01:08:31.227Z",
+      "dataHora": "2026-09-11T03:10:47.994Z",
       "viewport": "1440x900x1",
       "rolagem": {
-        "altura": 10169,
+        "altura": 10299,
         "imgs": 0,
         "carregadas": 0
       },
       "data": {
         "url": "file:///C:/Users/augus/orca/workspaces/landing-page-pessoal/Issue-45-degrau-movel-da-escala-tipografica/wireframes/lp-final.html",
-        "altura": 10169,
+        "altura": 10299,
         "fontes": {
           "status": "loaded",
           "carregadas": 33
@@ -10728,8 +10753,8 @@
           "h": 900,
           "dpr": 1
         },
-        "telas": 11.3,
-        "telas_base900_legado": 11.3,
+        "telas": 11.4,
+        "telas_base900_legado": 11.4,
         "metricaV2_hsvS015": 0.4,
         "corPerceptivel_C005": 0.4,
         "corForte_C012": 0.4,
@@ -10738,14 +10763,14 @@
         "fundos": [
           {
             "cor": "rgb(247,245,239)",
-            "pct": 67.5,
+            "pct": 67.6,
             "L": 0.97,
             "C": 0.008,
             "H": 91
           },
           {
             "cor": "rgb(232,227,217)",
-            "pct": 17.7,
+            "pct": 17.5,
             "L": 0.92,
             "C": 0.014,
             "H": 85
@@ -10766,7 +10791,7 @@
           },
           {
             "cor": "rgb(255,255,255)",
-            "pct": 1.2,
+            "pct": 1.3,
             "L": 1,
             "C": 0,
             "H": 90
@@ -10785,17 +10810,17 @@
           "video": 0,
           "canvas": 0
         },
-        "midiaTotalPor1000": 0.2,
+        "midiaTotalPor1000": 0.19,
         "keyframes": 3,
         "nomes": [
           "rail-scroll",
           "heroUp",
           "heroLine"
         ],
-        "keyframesPor1000": 0.3,
+        "keyframesPor1000": 0.29,
         "folhasBloqueadas": 1,
         "emTransicao": 75,
-        "emTransicaoPor1000": 7.38,
+        "emTransicaoPor1000": 7.28,
         "animacoesAtivas": 9,
         "duracoes": [
           [
@@ -10844,8 +10869,8 @@
             "letterSpacing": "-5.76px",
             "textTransform": "none",
             "inFirstViewport": true,
-            "largura_ch": 9,
-            "maiorLarguraCh": 9,
+            "largura_ch": 7,
+            "maiorLarguraCh": 7,
             "fracaoContidaMin": 1,
             "vistoEmAmostras": "5/5"
           },
@@ -10953,7 +10978,7 @@
         "caixaAlta": {
           "elementos": 23,
           "caracteresTotais": 467,
-          "caracteresPor1000px": 45.92,
+          "caracteresPor1000px": 45.34,
           "semNeutralizar": 13,
           "passeNeutralizado": true,
           "amostras": 6

--- a/docs/design/tipografia/medir.mjs
+++ b/docs/design/tipografia/medir.mjs
@@ -94,8 +94,10 @@ const CSS_REVELADOR_OFF = `
 // a cópia no PESQUISA-TIPOGRAFIA.md §8 tem que bater com ela.
 const CSS_ESCALA = `
   body { font-size: 1rem; line-height: 1.6; }
-  .hero-headline { font-size: clamp(3rem, 10vw, 9rem) !important; line-height: .9 !important;
-    letter-spacing: -.04em !important; text-transform: none !important; max-width: none !important; }
+  .hero-headline { font-size: clamp(3.0625rem, max(10vw, min(14vw, 3.375rem)), 9rem) !important;
+    line-height: clamp(.9em, 3.375rem, 1em) !important;
+    letter-spacing: -.04em !important; text-transform: none !important; max-width: none !important;
+    overflow-wrap: anywhere !important; }
   .slab-headline { font-size: clamp(2.25rem, 5vw, 4.5rem) !important; line-height: 1.05 !important;
     letter-spacing: -.02em !important; text-transform: none !important; }
   .qml-quote p, .ciere-flow-wrap, .about-copy p { font-size: clamp(1.5rem, 2.22vw, 2rem) !important;

--- a/docs/design/tipografia/medir.mjs
+++ b/docs/design/tipografia/medir.mjs
@@ -13,6 +13,7 @@
 // Opções:
 //     --so-local          mede apenas a lp-final.html e as variantes de escala
 //     --so-referencias    mede apenas os 18 sites externos
+//     --refs-moveis       mede as referencias nos tres viewports moveis
 //     --chrome <caminho>  Chrome alternativo
 //     --saida <arquivo>   padrão: docs/design/tipografia/medicoes.json
 //
@@ -415,19 +416,24 @@ const saida = {
 };
 
 const VP = alvos.viewportPadrao, viewportsDaLP = alvos.viewportsDaLP;
+const refsMoveis = flag('--refs-moveis');
+const viewportsDasReferencias = refsMoveis ? alvos.viewportsMoveisDasReferencias : [VP];
 
 if (!flag('--so-local')) {
   for (const a of alvos.referencias) {
     if (SO && a.id !== SO) continue;
-    process.stderr.write(`medindo ${a.id} ... `);
-    const r = await medirPagina(cdp, a.url, VP);
-    r.rotulo = a.rotulo; r.url = a.url;
-    saida.referencias[a.id] = r;
-    const d = r.data;
-    process.stderr.write(r.status === 'sucesso'
-      ? `${d.tamTitulos[0] ?? '?'}px  razao ${d.razaoTituloWorkhorse ?? '?'}` +
-        (d._legado.divergeDoCorrigido ? `  [legado dizia ${d._legado.tamTitulos_semFiltro[0]}px]` : '') + '\n'
-      : `FALHA: ${r.erro}\n`);
+    for (const vp of viewportsDasReferencias) {
+      const chave = refsMoveis ? `${a.id}@${vp.w}` : a.id;
+      process.stderr.write(`medindo ${chave} ... `);
+      const r = await medirPagina(cdp, a.url, vp);
+      r.rotulo = a.rotulo; r.url = a.url;
+      saida.referencias[chave] = r;
+      const d = r.data;
+      process.stderr.write(r.status === 'sucesso'
+        ? `${d.tamTitulos[0] ?? '?'}px  razao ${d.razaoTituloWorkhorse ?? '?'}` +
+          (d._legado.divergeDoCorrigido ? `  [legado dizia ${d._legado.tamTitulos_semFiltro[0]}px]` : '') + '\n'
+        : `FALHA: ${r.erro}\n`);
+    }
   }
 }
 

--- a/docs/design/tipografia/medir.mjs
+++ b/docs/design/tipografia/medir.mjs
@@ -414,7 +414,7 @@ const saida = {
   variantesDaLP: {}
 };
 
-const VP = alvos.viewportPadrao, VM = alvos.viewportMovel;
+const VP = alvos.viewportPadrao, viewportsDaLP = alvos.viewportsDaLP;
 
 if (!flag('--so-local')) {
   for (const a of alvos.referencias) {
@@ -438,7 +438,7 @@ if (!flag('--so-referencias')) {
     { id: 'B-so-escala',           css: CSS_ESCALA,  js: null },
     { id: 'C-escala-evento-curto', css: CSS_ESCALA,  js: JS_EVENTO_CURTO }
   ];
-  for (const vp of [VP, VM]) {
+  for (const vp of viewportsDaLP) {
     for (const v of variantes) {
       const chave = `${v.id}@${vp.w}`;
       process.stderr.write(`medindo ${chave} ... `);

--- a/docs/design/tipografia/medir.mjs
+++ b/docs/design/tipografia/medir.mjs
@@ -365,7 +365,8 @@ async function medirPagina(cdp, url, vp, { css, js } = {}) {
       for (const [i, a] of amostras.entries()) {
         const g = a._diag || {};
         console.error(`    DIAG a${i}: caps=${a.caixaAlta?.nos?.length} reduce=${g.reduce}`
-          + ` dataReveal=${g.dataReveal} will=${g.willReveal} revealed=${g.isRevealed}`);
+          + ` dataReveal=${g.dataReveal} will=${g.willReveal} revealed=${g.isRevealed}`
+          + ` altura=${a.altura}`);
       }
     }
     const dados = unirAmostras(amostras, amostraCaps);


### PR DESCRIPTION
Fecha a #45. O corte de **89px e 5,57×** foi derivado de 18 peças medidas **só em 1440×900**. Este PR mede as mesmas peças no móvel, e o corte não sobrevive.

## O achado que muda a premissa da issue

A 390px, **quatro das cinco peças aprovadas ficam abaixo de 89px**:

| aprovada @390 | título | razão |
|---|---|---|
| `white-desert` | 200px | 12,5× |
| `aelixa` | **80px** | 5,71× |
| `lxlcreative` | **64px** | 4,00× |
| `paulkalkbrenner` | **60px** | 3,75× |
| `illoca` | **58px** | 4,46× |

Perseguir 89px a 390px deixaria a LP mais extrema que quatro quintos da própria referência do cliente. O título desta issue — *"390px continua do lado rejeitado"* — está certo contra a régua de desktop e **errado contra a régua de 390px**.

## O corte de cada largura, pelo método da §3.4

Pior aprovado contra melhor rejeitado, ponto médio — o mesmo método que produziu 89px:

| largura | corte de título | corte de razão |
|---|---|---|
| 320 | **não existe** — a variável **inverte**: `illoca` (aprovada) 47px fica abaixo de `lowmess` (rejeitada) 48px | 3,73× |
| 390 | **54px** | 3,66× |
| 768 | **70,5px** | 4,39× |
| 1024 · 1440 | 89px | 5,57× |

**A 320px uma das duas variáveis classificadoras falha.** Primeira vez neste projeto.

## O degrau, e o resultado medido

Três linhas mudam, todas dentro de `.hero-headline`:

```css
font-size:     clamp(3.0625rem, max(10vw, min(14vw, 3.375rem)), 9rem);
line-height:   clamp(.9em, 3.375rem, 1em);
overflow-wrap: anywhere;
```

A ponte `min(14vw, 3.375rem)` **só atua abaixo de 540px**, onde `10vw` ainda não alcançou 54px — de 540 para cima a curva é exatamente a anterior, e o segundo degrau e o teto de 144px ficam intocados. A entrelinha abre para um corpo no móvel e reencontra `0.9em` em 600px.

Medido em `--headed`, **33/33**, contra o corte da própria largura:

| largura | título | razão | corte T | corte R |
|---|---|---|---|---|
| 320 | **49px** | **3,77×** | não existe | 3,73× · cruza por **0,04** |
| 390 | **54px** | **4,15×** | 54px · cruza com **margem zero** | 3,66× |
| 768 | **77px** | **5,92×** | 70,5px | 4,39× |
| 1024 | **102px** | **7,85×** | 89px | 5,57× |
| 1440 | **144px** | **11,08×** | 89px | 5,57× |

**As cinco predições do plano bateram exatamente**, sem uma única divergência. O *workhorse* continua 13px nas quinze linhas, a variante `A-lp-atual` não se moveu em largura nenhuma, e as 18 referências mantêm título, razão e workhorse idênticos aos da `develop`.

## Efeito colateral não previsto, e medido

`overflow-wrap: anywhere` altera o cálculo de **tamanho intrínseco**, e com ele a altura:

| @1440 | escala anterior | com o degrau móvel |
|---|---|---|
| `B-so-escala` | 10.604px | **10.863px** |
| `C-escala-evento-curto` | 10.169px | **10.299px** |

+259px e +130px que **não** vêm do tamanho do tipo — o título continua 144px e a razão 11,08×. O custo da escala sobe de **+2.230px (+26,6%)** para **+2.513px (+30,1%)**, e o alvo de ≤5.500px do `PROBLEMA-v1` fica a **5.363px**. Continua remetido à #7.

## A altura instável da #46: duas hipóteses refutadas com dado

Ficou decidido no gate que a investigação entrava aqui. Não fechei a causa, mas eliminei as duas candidatas — com medição, não com opinião:

- **O revelador não move a altura.** Com `SONDA_DIAG=1` a 320px, `isRevealed` sobe de 0 para 5 entre as amostras e a altura permanece **11.644px nas cinco**. O `transform` dos blocos `[data-reveal]` não contribui.
- **Imagem preguiçosa também não.** A LP não tem elemento `<img>` algum: `rolagem.imgs` é **0**.

O desvio de ~25px aparece em **uma largura por rodada**, não sempre na mesma — `A@1440` mediu 8.374 e 8.350; `A@768` mediu 10.934 e 10.959. Nas outras quatorze linhas, três rodadas conferidas batem exatamente. Fica declarado na §9.1 que **toda altura publicada carrega ±25px**, e que diferença menor que isso não é sinal. O driver passa a imprimir a altura por amostra sob `SONDA_DIAG`.

## O que este PR não autoriza

- **Nada foi conferido em navegador.** As previsões de quebra de linha do plano — seis linhas a 320px, cinco a 390px — são previsão de composição, não observação.
- **O teste de overflow que eu havia especificado é insuficiente**, e quem apontou foi o próprio agente de design: o `h1` está dentro de `.hero-mask` com `overflow: hidden`, então **ausência de rolagem horizontal não prova que o texto não foi cortado**. Crítica visual é da #21 e do Gate C.
- **A classificação no móvel é frágil, em dois sentidos distintos.** A separação da amostra cai de 26px a 1440 para 8px a 390 e fica **negativa** a 320. A folga da LP até o corte é 0,04 em razão a 320 e **zero** em título a 390. N=5 aprovadas, e as dez rejeitadas vêm de um único agregador.
- **Nenhum arquivo de produto foi tocado.** A escala é medida por injeção; aplicar em `wireframes/lp-final.html` exige Gate D.

## Procedência do trabalho

| etapa | quem |
|---|---|
| instrumento em cinco larguras | `gpt-5.6-sol` medium |
| 54 medições móveis | `gpt-5.6-sol` medium |
| **projeto do degrau** | **`gpt-6-astra` xhigh** |
| aplicação do CSS | `agy` `gemini-3.8-flash-high` |
| cortes, verificação, documento | coordenador |

Dois commits foram feitos pelo coordenador porque o agente parou antes: o `e42e5cd` porque a cota do Codex esgotou com o plano já completo, e o `ba4b758` porque a sessão do agy encerrou por timeout com a medição já concluída. Nenhum valor foi alterado em nenhum dos dois.

Os 24 números citados na §8.4 foram conferidos um a um contra `medicoes.json` e `medicoes-movel.json`: **zero divergências**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
